### PR TITLE
:truck: Rename mixins.py to throttling.py

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ Features
    maykin_common/context_processors
    maykin_common/django_two_factor_auth
    maykin_common/migration_operations
-   maykin_common/mixins
+   maykin_common/throttling
    maykin_common/pdf
    maykin_common/views
    maykin_common/templatetags

--- a/docs/maykin_common/mixins.rst
+++ b/docs/maykin_common/mixins.rst
@@ -1,7 +1,0 @@
-======
-Mixins
-======
-
-.. automodule:: maykin_common.mixins
-    :members:
-    :undoc-members:

--- a/docs/maykin_common/throttling.rst
+++ b/docs/maykin_common/throttling.rst
@@ -1,0 +1,7 @@
+==========
+Throttling
+==========
+
+.. automodule:: maykin_common.throttling
+    :members:
+    :undoc-members:

--- a/maykin_common/throttling.py
+++ b/maykin_common/throttling.py
@@ -1,3 +1,7 @@
+"""
+Provide mixins for throttling/rate limiting in views.
+"""
+
 from collections.abc import Container
 from time import time
 from typing import Literal

--- a/tests/axes/test_axes_import.py
+++ b/tests/axes/test_axes_import.py
@@ -4,6 +4,6 @@ import pytest
 def test_module_import(settings):
     settings.INSTALLED_APPS = settings.INSTALLED_APPS + ["axes"]
     try:
-        import maykin_common.mixins  # noqa: F401
+        import maykin_common.throttling  # noqa: F401
     except ImportError:
-        pytest.fail("Module 'mixins' is not imported correctly.")
+        pytest.fail("Module 'throttling' is not imported correctly.")

--- a/tests/base/test_not_imported.py
+++ b/tests/base/test_not_imported.py
@@ -13,4 +13,4 @@ def test_2fa():
 
 def test_mixins():
     with pytest.raises(ImportError):
-        import maykin_common.mixins  # noqa: F401
+        import maykin_common.throttling  # noqa: F401


### PR DESCRIPTION
mixins as a module name is far too broad and ambiguous. In Django alone you commonly encounter model mixins, view mixins, admin mixins and form mixins.

Instead, the module is now named after the feature set that it implements rather than what/how it does that.