### PR TITLE
:fire: Remove the model form meta.exclude check

### DIFF
--- a/maykin_common/checks.py
+++ b/maykin_common/checks.py
@@ -1,48 +1,7 @@
 import os
 
 from django.conf import settings
-from django.core.checks import Error, Warning, register
-from django.forms import ModelForm
-
-
-def get_subclasses(cls):
-    for subclass in cls.__subclasses__():
-        yield from get_subclasses(subclass)
-        yield subclass
-
-
-@register()
-def check_modelform_exclude(app_configs, **kwargs):
-    """
-    Check that ModelForms use Meta.fields instead of Meta.exclude.
-
-    ModelForm.Meta.exclude is dangerous because it doesn't protect against
-    fields that are added later. Explicit white-listing is safer and prevents
-    bugs such as IMA #645.
-
-    This check piggy-backs on all form modules to be imported during Django
-    startup. It won't cover forms that are defined on the fly such as in
-    formset factories.
-    """
-    errors = []
-
-    for form in get_subclasses(ModelForm):
-        # ok, fields is defined
-        if form._meta.fields or getattr(form.Meta, "fields", None):
-            continue
-
-        # no `.fields` defined, so scream loud enough to prevent this
-        errors.append(
-            Error(
-                f"ModelForm {form.__module__}.{form.__name__} with Meta.exclude "
-                "detected, this is a bad practice",
-                hint="Use ModelForm.Meta.fields instead",
-                obj=form,
-                id="maykin.E001",
-            )
-        )
-
-    return errors
+from django.core.checks import Warning, register
 
 
 @register

--- a/tests/base/test_checks.py
+++ b/tests/base/test_checks.py
@@ -1,29 +1,8 @@
 from pathlib import Path
 
-from django.core.checks import Error, Warning
-from django.forms import ModelForm
+from django.core.checks import Warning
 
-from maykin_common.checks import check_missing_init_files, check_modelform_exclude
-
-
-def test_check_modelform_exclude(settings):
-    settings.DJANGO_PROJECT_DIR = settings.BASE_DIR
-
-    class DummyForm(ModelForm):
-        class Meta:
-            exclude = ("id",)  # noqa DJ006
-
-    errors = check_modelform_exclude(None)
-
-    assert errors == [
-        Error(
-            "ModelForm tests.base.test_checks.DummyForm with Meta.exclude detected, "
-            "this is a bad practice",
-            hint="Use ModelForm.Meta.fields instead",
-            obj=DummyForm,
-            id="maykin.E001",
-        )
-    ]
+from maykin_common.checks import check_missing_init_files
 
 
 def test_check_missing_init_files(settings):


### PR DESCRIPTION
This check performed the same check as Ruff's DJ006. Now that we're moving everything to Ruff, it's recommended to use that linter rule rather than relying on a system check that slows down runserver reloads and application startup time. Additionally, it removes some friction with third party form definitions that violate this requirement that we can't fix/address.