### PR TITLE
Fix VCR API reference building on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,3 +18,4 @@ python:
       path: .
       extra_requirements:
         - docs
+        - vcr


### PR DESCRIPTION
This fixed it in the `docs` tox env.
I didn't know about the hidden .readthedocs.yaml :smiling_face_with_tear: 