### PR TITLE
:sparkles: Tweak PDF generation utility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+0.6.0 (2025-07-10)
+==================
+
+PDF utilities feature release.
+
+* 💥 Renamed ``render_to_pdf`` to ``render_template_to_pdf``.
+* Exposed helper ``render_to_pdf`` to render HTML to PDF without needing the template
+  engine.
+* Added ``variant`` option, defaulting to ``pdf/ua-1`` (accessible PDFs).
+
 0.5.0 (2025-07-04)
 ==================
 

--- a/tests/pdf/test_pdf_generation.py
+++ b/tests/pdf/test_pdf_generation.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 
 import pytest
 
-from maykin_common.pdf import render_to_pdf
+from maykin_common.pdf import render_template_to_pdf
 
 
 def get_base_url():
@@ -28,11 +28,13 @@ def test_raises_if_setting_not_configured_properly(settings):
     settings.PDF_BASE_URL_FUNCTION = None
 
     with pytest.raises(NotImplementedError):
-        render_to_pdf("testapp/pdf/hello_world.html", {})
+        render_template_to_pdf("testapp/pdf/hello_world.html", {})
 
 
 def test_render_template_returns_html():
-    html, pdf = render_to_pdf("testapp/pdf/hello_world.html", {"world": "pytest"})
+    html, pdf = render_template_to_pdf(
+        "testapp/pdf/hello_world.html", {"world": "pytest"}
+    )
 
     assert isinstance(html, str)
     assert "Hello pytest" in html
@@ -41,21 +43,21 @@ def test_render_template_returns_html():
 
 def test_external_url_uses_default_resolver():
     with patch("maykin_common.pdf.weasyprint.default_url_fetcher") as mock_fetcher:
-        render_to_pdf("testapp/pdf/external_url.html", {})
+        render_template_to_pdf("testapp/pdf/external_url.html", {})
 
     mock_fetcher.assert_called_once_with("https://example.com/index.css")
 
 
 def test_local_asset_does_not_use_default_resolver():
     with patch("maykin_common.pdf.weasyprint.default_url_fetcher") as mock_fetcher:
-        render_to_pdf("testapp/pdf/local_url.html", {})
+        render_template_to_pdf("testapp/pdf/local_url.html", {})
 
     mock_fetcher.assert_not_called()
 
 
 def test_render_with_missing_asset():
     with patch("maykin_common.pdf.weasyprint.default_url_fetcher") as mock_fetcher:
-        render_to_pdf("testapp/pdf/missing_asset.html", {})
+        render_template_to_pdf("testapp/pdf/missing_asset.html", {})
 
     mock_fetcher.assert_called_once_with("http://testserver/static/non_existent.css")
 
@@ -65,7 +67,7 @@ def test_resolves_assets_in_debug_mode(settings):
     settings.DEBUG = True
 
     with patch("maykin_common.pdf.weasyprint.default_url_fetcher") as mock_fetcher:
-        render_to_pdf("testapp/pdf/local_url.html", {})
+        render_template_to_pdf("testapp/pdf/local_url.html", {})
 
     mock_fetcher.assert_not_called()
 
@@ -74,7 +76,7 @@ def test_fully_qualified_static_url(settings):
     settings.STATIC_URL = "http://testserver/static/"
 
     with patch("maykin_common.pdf.weasyprint.default_url_fetcher") as mock_fetcher:
-        render_to_pdf("testapp/pdf/local_url.html", {})
+        render_template_to_pdf("testapp/pdf/local_url.html", {})
 
     mock_fetcher.assert_not_called()
 
@@ -91,6 +93,6 @@ def test_other_storages_than_file_system_storage(settings):
     }
 
     with patch("maykin_common.pdf.weasyprint.default_url_fetcher") as mock_fetcher:
-        render_to_pdf("testapp/pdf/local_url.html", {})
+        render_template_to_pdf("testapp/pdf/local_url.html", {})
 
     mock_fetcher.assert_called_with("http://testserver/testapp/some.css")


### PR DESCRIPTION
* Generate accessible variants by default
* Split utility in template/non-template part

I needed these changes while incorporating the lib in Open Forms.