### PR TITLE
:bricks: Set up celery worker post-fork hook

### DIFF
--- a/docs/otel.rst
+++ b/docs/otel.rst
@@ -79,6 +79,10 @@ environment variable usage.
    data to. Check default-project or the Maykin docs with some reference instructions
    if your project has not been prepared yet.
 
+If you use Celery with process pool (the default), then your worker invocation must set
+``_OTEL_DEFER_SETUP=True`` in the environment to defer the initialization until the
+worker process has forked.
+
 Python Open Telemetry SDK
 =========================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ tests = [
     "ruff",
     "pyright",
     "django-stubs",
+    "celery",
 ]
 docs = [
     "sphinx",


### PR DESCRIPTION
Celery workers that run in a process pool must defer there otel initialization until the worker process has forked, which is signaled by celery in a hook. Failing to do so leads to a shared instance ID for all workers, which competes with the metrics/meters registered and produces wrong results. It can also lead to deadlocks because the open telemetry machinery uses threading locks.

This does require the applications to pass
_OTEL_DEFER_SETUP=true in the worker environment, since there's no clear worker detection mechanism.

There are also *other* concurrency models, e.g. using threads instead of processes, which we can't reliable detect, so the envvar approach should be sufficient.