### PR TITLE
:sparkles: Add sphinx directives to generate envvar documentation

### DIFF
--- a/docs/env_docs_helpers.rst
+++ b/docs/env_docs_helpers.rst
@@ -1,0 +1,71 @@
+.. _env_docs_helpers:
+
+==========================================
+Environment variable documentation helpers
+==========================================
+
+Any environment variables that are loaded using :func:`maykin_common.config.config`,
+can be documented using the documentation helpers (unless ``add_to_docs`` is explicitly set to ``False``).
+Documentation per environment variable can be added by providing a ``help_text`` and
+(optionally) a ``group`` to document the environment variable under.
+
+
+.. code:: python
+
+    from maykin_common.config_helpers import config
+
+    ALLOWED_HOSTS = config(
+        "ALLOWED_HOSTS",
+        default="",
+        split=True,
+        help_text=(
+            "a comma separated (without spaces!) list of domains that serve "
+            "the installation. Used to protect against Host header attacks."
+        ),
+        group="Required",
+    )
+
+In order to document environment variables that are defined in this way, there are three
+Sphinx directives that can be used.
+
+To document all groups of environment variables, the ``config-all-params`` directive
+(:class:`maykin_common.documentation.config_directives.ConfigAllParamsDirective`) can be used.
+This directive accepts the following optional arguments:
+
+* ``members-groups`` to only use the specified groups
+* ``exclude-groups`` to exclude the specified groups (cannot be used together with ``members-groups``)
+* ``exclude-params`` to exclude the specified environment variables
+
+Example usage:
+
+.. code:: rst
+
+    .. config-all-params::
+        :exclude-groups: Celery, Database
+
+
+To document a specific group of environment variables, the ``config-group`` directive
+(:class:`maykin_common.documentation.config_directives.ConfigGroupDirective`) can be used.
+This directive accepts the following optional arguments:
+
+* ``members`` to only use the specified environment variables
+* ``exclude`` to exclude the specified environment variables (cannot be used together with ``members``)
+
+Example usage:
+
+.. code:: rst
+
+    .. config-group:: Database
+        :exclude: DB_POOL_MAX_LIFETIME, DB_POOL_NUM_WORKERS
+
+To document a single environment variable, the ``config-param`` directive
+(:class:`maykin_common.documentation.config_directives.ConfigParamDirective`) can be used.
+This directive accepts the following optional arguments:
+
+* ``default`` to override the default as defined in the code
+
+.. code:: rst
+
+    .. config-param:: DISABLE_2FA
+        :default: True
+

--- a/docs/env_docs_helpers.rst
+++ b/docs/env_docs_helpers.rst
@@ -6,23 +6,44 @@ Environment variable documentation helpers
 
 Any environment variables that are loaded using :func:`maykin_common.config.config`,
 can be documented using the documentation helpers (unless ``add_to_docs`` is explicitly set to ``False``).
-Documentation per environment variable can be added by providing a ``help_text`` and
-(optionally) a ``group`` to document the environment variable under.
+Documentation per environment variable can be added by providing the ``documentation``
+parameter, which has the following attributes:
 
+* ``help_text``: the description of the environment variable.
+* ``group``: the name of the group to list this environment variable under
+  (defaults to ``Required`` if no default is specified, otherwise ``Optional``).
+* ``add_to_docs``: whether or not this environment variable should be included in the docs (default ``True``)
+* ``auto_display_default``: whether or not the default specified to the ``config`` helper
+  should be displayed in the documentation (default ``True``)
 
 .. code:: python
 
-    from maykin_common.config_helpers import config
+    from maykin_common.config_helpers import config, DocumentationParams
 
     ALLOWED_HOSTS = config(
         "ALLOWED_HOSTS",
         default="",
         split=True,
-        help_text=(
-            "a comma separated (without spaces!) list of domains that serve "
-            "the installation. Used to protect against Host header attacks."
-        ),
-        group="Required",
+        documentation=DocumentationParams(
+            help_text=(
+                "a comma separated (without spaces!) list of domains that serve "
+                "the installation. Used to protect against Host header attacks."
+            ),
+            group="Required",
+        )
+    )
+
+To exclude an environment variable from the documentation, the following shorthand
+can be used:
+
+.. code:: python
+
+    from maykin_common.config_helpers import config, no_doc
+
+    VARIABLE_TO_BE_EXCLUDED = config(
+        "VARIABLE_TO_BE_EXCLUDED",
+        default="",
+        documentation=no_doc
     )
 
 In order to document environment variables that are defined in this way, there are three

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ Features
    :caption: Contents:
 
    quickstart
+   env_docs_helpers
    health_checks
    otel
    apis

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -156,6 +156,9 @@ Reading settings from the environment
 
 Use the :func:`maykin_common.config.config` helper.
 
+This configuration helper can be used together with Sphinx directives to generate documentation
+for environment variables, see :ref:`env_docs_helpers` for more information.
+
 Health checks
 -------------
 

--- a/docs/reference/documentation_helpers.rst
+++ b/docs/reference/documentation_helpers.rst
@@ -1,0 +1,10 @@
+=====================
+Documentation helpers
+=====================
+
+Sphinx directives that can be used to document environment variables that are loaded
+using the :func:`maykin_common.config.config` function.
+
+.. automodule:: maykin_common.documentation.config_directives
+    :members: ConfigParamDirective, ConfigGroupDirective, ConfigAllParamsDirective
+    :undoc-members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -27,6 +27,12 @@ Python API reference.
 
 .. toctree::
    :maxdepth: 1
+   :caption: Documentation helpers
+
+   documentation_helpers
+
+.. toctree::
+   :maxdepth: 1
    :caption: Axes
 
    throttling

--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import csv
 import io
 from collections.abc import Callable, Sequence
-from typing import Literal, Never, assert_never, overload
+from dataclasses import dataclass
+from typing import Any, Literal, Never, assert_never, overload
 
 from decouple import Csv, Undefined, config as _config, undefined
 
@@ -17,7 +18,14 @@ __all__ = ["config"]
 
 
 @overload
-def config(option: str) -> str: ...
+def config(
+    option: str,
+    *,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
+) -> str: ...
 
 
 # discourage passing a str default with split=True
@@ -28,6 +36,10 @@ def config[T](
     default: str,
     split: Literal[True],
     cast: Callable[[str], T] | Undefined = undefined,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
 ) -> Never: ...
 
 
@@ -38,6 +50,10 @@ def config[T](
     default: Sequence[T],
     split: Literal[True],
     cast: Callable[[str], T] | Undefined = undefined,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
 ) -> list[T]: ...
 
 
@@ -48,6 +64,10 @@ def config(
     default: Undefined = undefined,
     split: Literal[True],
     cast: Undefined = undefined,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
 ) -> list[str]: ...
 
 
@@ -58,25 +78,61 @@ def config[T](
     default: Undefined = undefined,
     split: Literal[True],
     cast: Callable[[str], T],
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
 ) -> list[T]: ...
 
 
 @overload
-def config(option: str, *, default: None) -> str | None: ...
-
-
-@overload
-def config[T](option: str, *, default: T | Undefined = undefined) -> T: ...
-
-
-# because we can't express difference / negation types: object \ None
-@overload
-def config(option: str, *, default: None, cast: Callable) -> Never: ...
+def config(
+    option: str,
+    *,
+    default: None,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
+) -> str | None: ...
 
 
 @overload
 def config[T](
-    option: str, *, default: str | Undefined = undefined, cast: Callable[[str], T]
+    option: str,
+    *,
+    default: T | Undefined = undefined,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
+) -> T: ...
+
+
+# because we can't express difference / negation types: object \ None
+@overload
+def config(
+    option: str,
+    *,
+    default: None,
+    cast: Callable,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
+) -> Never: ...
+
+
+@overload
+def config[T](
+    option: str,
+    *,
+    default: str | Undefined = undefined,
+    cast: Callable[[str], T],
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
 ) -> T: ...
 
 
@@ -86,6 +142,10 @@ def config[T](
     default: T | Sequence[T] | None | str | Undefined = undefined,
     split: bool = False,
     cast: Callable[[str], T] | Undefined = undefined,
+    help_text: str = "",
+    group: str | None = None,
+    add_to_docs: bool = True,
+    auto_display_default: bool = True,
 ) -> str | None | T | Sequence[T]:
     """
     Pull a config parameter from the environment.
@@ -117,7 +177,34 @@ def config[T](
         ...     default="123",
         ...     cast=lambda v: int(v) if v is not None else None,
         ... )  # typed as int | None
+
+    Several parameters are available to generate documentation for environment variables
+    with Sphinx directives provided by this library:
+
+    help_text : str
+        The description of this environment variable.
+    group : str, optional
+        The name of the group this environment variable belongs to.
+        Defaults to "Required" or "Optional" depending on whether a ``default``
+        is passed.
+    add_to_docs : bool, default ``True``
+        Indicates whether this environment variable should be displayed in the
+        documentation.
+    auto_display_default : bool, default ``True``
+        Indicates whether the documentation directives should display the specified
+        default. Can be set to ``False`` if you want to manually specify a default.
     """
+
+    variable = EnvironmentVariable(
+        name=option,
+        default=default,
+        help_text=help_text,
+        group=group,
+        auto_display_default=auto_display_default,
+    )
+
+    if add_to_docs:
+        ENVVAR_REGISTRY[option] = variable
 
     if split:
         assert isinstance(default, Undefined | Sequence), (
@@ -185,3 +272,27 @@ def _dumps(given_default: Sequence) -> str:
     fd.seek(0)
     default = fd.read()
     return default
+
+
+ENVVAR_REQUIRED_GROUP = "Required"
+ENVVAR_OPTIONAL_GROUP = "Optional"
+
+
+@dataclass
+class EnvironmentVariable:
+    name: str
+    default: Any
+    help_text: str
+    group: str | None = None
+    auto_display_default: bool = True
+
+    def __post_init__(self):
+        if not self.group:
+            self.group = (
+                ENVVAR_REQUIRED_GROUP
+                if isinstance(self.default, Undefined)
+                else ENVVAR_OPTIONAL_GROUP
+            )
+
+
+ENVVAR_REGISTRY: dict[str, EnvironmentVariable] = {}

--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -1,7 +1,5 @@
 """
 Utilities to read and process configuration for a project.
-
-.. todo:: Incorporate the Team Bron documentation options for parameters.
 """
 
 from __future__ import annotations
@@ -14,18 +12,41 @@ from typing import Any, Literal, Never, assert_never, overload
 
 from decouple import Csv, Undefined, config as _config, undefined
 
-__all__ = ["config"]
+__all__ = ["config", "DocumentationParams"]
+
+
+@dataclass(slots=True)
+class DocumentationParams:
+    """
+    Dataclass to define the parameters for documentation generation for environment
+    variables loaded via the :func:`maykin_common.config.config` helper
+
+    help_text : str
+        The description of this environment variable.
+    group : str, optional
+        The name of the group this environment variable belongs to.
+        Defaults to "Required" or "Optional" depending on whether a ``default``
+        is passed.
+    add_to_docs : bool, default ``True``
+        Indicates whether this environment variable should be displayed in the
+        documentation.
+    auto_display_default : bool, default ``True``
+        Indicates whether the documentation directives should display the specified
+        default. Can be set to ``False`` if you want to manually specify a default.
+    """
+
+    help_text: str = ""
+    group: str | None = None
+    add_to_docs: bool = True
+    auto_display_default: bool = True
+
+
+"""Shorthand to not include an environment variable in generated documentation"""
+no_doc = DocumentationParams(add_to_docs=False)
 
 
 @overload
-def config(
-    option: str,
-    *,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
-) -> str: ...
+def config(option: str, *, documentation: DocumentationParams | None = None) -> str: ...
 
 
 # discourage passing a str default with split=True
@@ -36,10 +57,7 @@ def config[T](
     default: str,
     split: Literal[True],
     cast: Callable[[str], T] | Undefined = undefined,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> Never: ...
 
 
@@ -50,10 +68,7 @@ def config[T](
     default: Sequence[T],
     split: Literal[True],
     cast: Callable[[str], T] | Undefined = undefined,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> list[T]: ...
 
 
@@ -64,10 +79,7 @@ def config(
     default: Undefined = undefined,
     split: Literal[True],
     cast: Undefined = undefined,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> list[str]: ...
 
 
@@ -78,22 +90,13 @@ def config[T](
     default: Undefined = undefined,
     split: Literal[True],
     cast: Callable[[str], T],
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> list[T]: ...
 
 
 @overload
 def config(
-    option: str,
-    *,
-    default: None,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    option: str, *, default: None, documentation: DocumentationParams | None = None
 ) -> str | None: ...
 
 
@@ -102,10 +105,7 @@ def config[T](
     option: str,
     *,
     default: T | Undefined = undefined,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> T: ...
 
 
@@ -116,10 +116,7 @@ def config(
     *,
     default: None,
     cast: Callable,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> Never: ...
 
 
@@ -129,10 +126,7 @@ def config[T](
     *,
     default: str | Undefined = undefined,
     cast: Callable[[str], T],
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> T: ...
 
 
@@ -142,10 +136,7 @@ def config[T](
     default: T | Sequence[T] | None | str | Undefined = undefined,
     split: bool = False,
     cast: Callable[[str], T] | Undefined = undefined,
-    help_text: str = "",
-    group: str | None = None,
-    add_to_docs: bool = True,
-    auto_display_default: bool = True,
+    documentation: DocumentationParams | None = None,
 ) -> str | None | T | Sequence[T]:
     """
     Pull a config parameter from the environment.
@@ -178,32 +169,24 @@ def config[T](
         ...     cast=lambda v: int(v) if v is not None else None,
         ... )  # typed as int | None
 
-    Several parameters are available to generate documentation for environment variables
-    with Sphinx directives provided by this library:
+    The ``documentation`` parameter is available to generate documentation for
+    environment variables with Sphinx directives provided by this library:
 
-    help_text : str
-        The description of this environment variable.
-    group : str, optional
-        The name of the group this environment variable belongs to.
-        Defaults to "Required" or "Optional" depending on whether a ``default``
-        is passed.
-    add_to_docs : bool, default ``True``
-        Indicates whether this environment variable should be displayed in the
-        documentation.
-    auto_display_default : bool, default ``True``
-        Indicates whether the documentation directives should display the specified
-        default. Can be set to ``False`` if you want to manually specify a default.
+    documentation (:class:`maykin_common.config.DocumentationParams`)
     """
 
-    variable = EnvironmentVariable(
-        name=option,
-        default=default,
-        help_text=help_text,
-        group=group,
-        auto_display_default=auto_display_default,
-    )
+    if not documentation:
+        # Instantiate the defaults
+        documentation = DocumentationParams()
 
-    if add_to_docs:
+    if documentation.add_to_docs:
+        variable = EnvironmentVariable(
+            name=option,
+            default=default,
+            help_text=documentation.help_text,
+            group=documentation.group,
+            auto_display_default=documentation.auto_display_default,
+        )
         ENVVAR_REGISTRY[option] = variable
 
     if split:
@@ -278,7 +261,7 @@ ENVVAR_REQUIRED_GROUP = "Required"
 ENVVAR_OPTIONAL_GROUP = "Optional"
 
 
-@dataclass
+@dataclass(slots=True)
 class EnvironmentVariable:
     name: str
     default: Any

--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -20,29 +20,31 @@ class DocumentationParams:
     """
     Dataclass to define the parameters for documentation generation for environment
     variables loaded via the :func:`maykin_common.config.config` helper
-
-    help_text : str
-        The description of this environment variable.
-    group : str, optional
-        The name of the group this environment variable belongs to.
-        Defaults to "Required" or "Optional" depending on whether a ``default``
-        is passed.
-    add_to_docs : bool, default ``True``
-        Indicates whether this environment variable should be displayed in the
-        documentation.
-    auto_display_default : bool, default ``True``
-        Indicates whether the documentation directives should display the specified
-        default. Can be set to ``False`` if you want to manually specify a default.
     """
 
     help_text: str = ""
+    """
+    The description of this environment variable.
+    """
     group: str | None = None
+    """
+    The name of the group this environment variable belongs to.
+    Defaults to "Required" or "Optional" depending on whether a ``default`` is passed.
+    """
     add_to_docs: bool = True
+    """
+    Indicates whether this environment variable should be displayed in the
+    documentation.
+    """
     auto_display_default: bool = True
+    """
+    Indicates whether the documentation directives should display the specified
+    default. Can be set to ``False`` if you want to manually specify a default.
+    """
 
 
-"""Shorthand to not include an environment variable in generated documentation"""
 no_doc = DocumentationParams(add_to_docs=False)
+"""Shorthand to not include an environment variable in generated documentation"""
 
 
 @overload
@@ -172,7 +174,7 @@ def config[T](
     The ``documentation`` parameter is available to generate documentation for
     environment variables with Sphinx directives provided by this library:
 
-    documentation (:class:`maykin_common.config.DocumentationParams`)
+    :param documentation: See :class:`maykin_common.config.DocumentationParams`
     """
 
     if not documentation:

--- a/maykin_common/documentation/config_directives.py
+++ b/maykin_common/documentation/config_directives.py
@@ -1,0 +1,256 @@
+import warnings
+from collections import defaultdict
+from collections.abc import Collection
+
+from decouple import Undefined, undefined
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+from docutils.parsers.rst.states import RSTState
+from docutils.statemachine import ViewList
+
+from maykin_common.config import (
+    ENVVAR_OPTIONAL_GROUP,
+    ENVVAR_REGISTRY,
+    ENVVAR_REQUIRED_GROUP,
+    EnvironmentVariable,
+)
+
+
+def get_envvar(param_name: str) -> EnvironmentVariable:
+    """
+    Get an environment variable and its metadata from the registry by name
+
+    :arg param_name: name of the environment variable
+    :returns: the environment variable with metadata for documentation
+    """
+    var = ENVVAR_REGISTRY.get(param_name)
+    if not var:
+        raise ValueError(f"Envvar with name {param_name} not found in registry")
+    return var
+
+
+def get_envvar_group(
+    group_name: str,
+    members: Collection[str] | None = None,
+    exclude: Collection[str] | None = None,
+) -> list[EnvironmentVariable]:
+    """
+    Get a list of environment variables and their metadata from
+    the registry by group name
+
+    :arg group_name: name of the environment variable group
+    :arg members: name(s) of the environment variable to include from the group
+    :arg exclude: name(s) of the environment variable to exclude from the group
+    :returns: the list of environment variables with metadata for documentation
+    """
+    variables = (v for v in ENVVAR_REGISTRY.values() if v.group == group_name)
+    if members:
+        variables = (v for v in variables if v.name in members)
+    if exclude:
+        variables = (v for v in variables if v.name not in exclude)
+    return list(variables)
+
+
+def document_param(
+    var: EnvironmentVariable,
+    state: RSTState,
+    default: str | None | Undefined = undefined,
+) -> nodes.Node:
+    """
+    Create an rST node to document an environment variable
+
+    :arg var: the environment variable metadata
+    :arg state: the reStructuredText state machine state
+    :arg default: an optional override for the default of the environment variable
+    :returns: the node with a list item to document the environment variable
+    """
+    para = nodes.inline()
+
+    result = f"* ``{var.name}``: "
+
+    if var.help_text:
+        result += var.help_text
+        if not var.help_text.endswith("."):
+            result += "."
+    else:
+        warnings.warn(f"missing help_text for environment variable {var}", stacklevel=2)
+
+    if var.auto_display_default:
+        # Use explicitly provided default to override the default defined in code
+        default_value = default if default is not undefined else var.default
+        if default_value is not undefined:
+            text = "(empty string)" if default_value == "" else str(default_value)
+            result += f" Defaults to: ``{text}``."
+
+    # Make sure the line is rendered as rST
+    vl = ViewList()
+    vl.append(var.help_text, "<param_help>")
+    text, _ = state.inline_text(result, 0)
+    para += text
+
+    # TODO cleaner way to do this?
+    para += nodes.raw("", "<br>", format="html")
+
+    return para
+
+
+def document_group(
+    group: Collection[EnvironmentVariable], state: RSTState
+) -> nodes.Node:
+    """
+    Create an rST node to document a group of environment variables
+
+    :arg group: the list of environment variables with metadata
+    :arg state: the reStructuredText state machine state
+    :returns: the node with list items to document the environment variables
+    """
+    para = nodes.paragraph()
+    for var in group:
+        para += document_param(var, state)
+    return para
+
+
+class ConfigParamDirective(Directive):
+    """
+    Directive to generate documentation for a specific parameter (environment variable)
+
+    :arg default: override the default of the environment variable
+    :returns: the node with a list item to document the environment variable
+    """
+
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+
+    option_spec = {
+        "default": directives.unchanged,
+    }
+
+    def run(self):
+        param_name = self.arguments[0]
+        default = self.options.get("default", undefined)
+
+        var = get_envvar(param_name)
+        para = document_param(var, self.state, default=default)
+
+        return [para]
+
+
+class ConfigGroupDirective(Directive):
+    """
+    Directive to generate documentation for a specific parameter group
+
+    :arg members: the names of the environment variables from the group that should be
+        displayed
+    :arg exclude: the names of the environment variables from the group that should not
+        be displayed
+    :returns: the node with list items to document the environment variables
+    """
+
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 0
+    final_argument_whitespace = True
+
+    option_spec = {
+        "members": directives.unchanged,
+        "exclude": directives.unchanged,
+    }
+
+    def run(self):
+        group_name = self.arguments[0]
+
+        # Get members and split by comma, stripping extra whitespace
+        members_str = self.options.get("members", "")
+        members = [m.strip() for m in members_str.split(",") if m.strip()]
+
+        # Same for exclude
+        exclude_str = self.options.get("exclude", "")
+        exclude = [e.strip() for e in exclude_str.split(",") if e.strip()]
+
+        if members and exclude:
+            raise ValueError("cannot use both `members` and `exclude` options")
+
+        group = get_envvar_group(group_name, members=members, exclude=exclude)
+
+        return [document_group(group, self.state)]
+
+
+class ConfigAllParamsDirective(Directive):
+    """
+    Directive to generate documentation for all parameter groups
+
+    :arg members-groups: the names of the environment variable groups that should be
+        displayed
+    :arg exclude-groups: the names of the environment variable groups that should not be
+        displayed
+    :arg exclude-groups: the names of the environment variables that should not be
+        displayed
+    :returns: the node with sections to document the environment variables per group
+    """
+
+    has_content = False
+    required_arguments = 0
+    optional_arguments = 0
+    final_argument_whitespace = True
+
+    option_spec = {
+        "members-groups": directives.unchanged,
+        "exclude-groups": directives.unchanged,
+        "exclude-params": directives.unchanged,
+    }
+
+    def run(self):
+        members_groups = self.options.get("members-groups", "")
+        exclude_groups = self.options.get("exclude-groups", "")
+        exclude_params = self.options.get("exclude-params", "")
+
+        if members_groups and exclude_groups:
+            raise ValueError(
+                "cannot use both `members-groups` and `exclude-groups` options"
+            )
+
+        grouped_vars = defaultdict(list)
+        for var in ENVVAR_REGISTRY.values():
+            # Check if the group should be included
+            if members_groups and var.group not in members_groups:
+                continue
+            elif exclude_groups and var.group in exclude_groups:
+                continue
+
+            # Check if the param should be included
+            if var.name in exclude_params:
+                continue
+
+            grouped_vars[var.group].append(var)
+
+        root = nodes.container()
+
+        def handle_group(group_name, variables, root):
+            group = nodes.section()
+            group["ids"].append(group_name)
+
+            group += nodes.title(text=group_name)
+            group += document_group(variables, self.state)
+            root += group
+
+        # Make sure the required vars are listed first
+        if required_vars := grouped_vars.pop(ENVVAR_REQUIRED_GROUP, None):
+            handle_group(ENVVAR_REQUIRED_GROUP, required_vars, root)
+
+        optional_vars = grouped_vars.pop(ENVVAR_OPTIONAL_GROUP, None)
+        for group_name, variables in grouped_vars.items():
+            handle_group(group_name, variables, root)
+
+        # Make sure the optional vars are listed first
+        if optional_vars:
+            handle_group(ENVVAR_OPTIONAL_GROUP, optional_vars, root)
+
+        return [root]
+
+
+def setup(app):  # pragma: no cover
+    app.add_directive("config-param", ConfigParamDirective)
+    app.add_directive("config-group", ConfigGroupDirective)
+    app.add_directive("config-all-params", ConfigAllParamsDirective)

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -113,7 +113,7 @@ def setup_otel() -> None:
     # e.g. in celery workers with a process pool that fork other processes. Detecting
     # if we're running in a celery master or worker process is not obvious, so instead
     # we look at an explicit environment variable.
-    defer_setup: bool = config("_OTEL_DEFER_SETUP", default=False)
+    defer_setup: bool = config("_OTEL_DEFER_SETUP", default=False, add_to_docs=False)
 
     # in a uwsgi worker, defer the otel initialization until after the processes have
     # forked
@@ -175,7 +175,7 @@ def _setup_otel() -> None:
 
 def load_exporters():
     protocol: ExportProtocol = config(
-        OTEL_EXPORTER_OTLP_PROTOCOL, default=DEFAULT_PROTOCOL
+        OTEL_EXPORTER_OTLP_PROTOCOL, default=DEFAULT_PROTOCOL, add_to_docs=False
     )
     match protocol:
         case "grpc":
@@ -202,7 +202,9 @@ def load_exporters():
 
 def aggregate_resource(resource: Resource) -> Resource:
     _enable_resource_detector: bool = config(
-        "_OTEL_ENABLE_CONTAINER_RESOURCE_DETECTOR", default=False
+        "_OTEL_ENABLE_CONTAINER_RESOURCE_DETECTOR",
+        default=False,
+        add_to_docs=False,
     )
     if not _enable_resource_detector:
         return resource

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -38,7 +38,7 @@ from opentelemetry.sdk.resources import (
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from ..config import config
+from ..config import config, no_doc
 from ..settings import get_setting
 from .processors import CustomAttributeSpanProcessor
 
@@ -113,7 +113,7 @@ def setup_otel() -> None:
     # e.g. in celery workers with a process pool that fork other processes. Detecting
     # if we're running in a celery master or worker process is not obvious, so instead
     # we look at an explicit environment variable.
-    defer_setup: bool = config("_OTEL_DEFER_SETUP", default=False, add_to_docs=False)
+    defer_setup: bool = config("_OTEL_DEFER_SETUP", default=False, documentation=no_doc)
 
     # in a uwsgi worker, defer the otel initialization until after the processes have
     # forked
@@ -175,7 +175,7 @@ def _setup_otel() -> None:
 
 def load_exporters():
     protocol: ExportProtocol = config(
-        OTEL_EXPORTER_OTLP_PROTOCOL, default=DEFAULT_PROTOCOL, add_to_docs=False
+        OTEL_EXPORTER_OTLP_PROTOCOL, default=DEFAULT_PROTOCOL, documentation=no_doc
     )
     match protocol:
         case "grpc":
@@ -204,7 +204,7 @@ def aggregate_resource(resource: Resource) -> Resource:
     _enable_resource_detector: bool = config(
         "_OTEL_ENABLE_CONTAINER_RESOURCE_DETECTOR",
         default=False,
-        add_to_docs=False,
+        documentation=no_doc,
     )
     if not _enable_resource_detector:
         return resource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ tests = [
     "decouple-types",
     "redis",
     "time-machine",
+    "sphinx",
 ]
 docs = [
     "sphinx",

--- a/tests/base/test_config_directives.py
+++ b/tests/base/test_config_directives.py
@@ -5,7 +5,7 @@ from docutils.core import publish_doctree
 from docutils.parsers.rst import directives
 
 import maykin_common.config
-from maykin_common.config import config
+from maykin_common.config import DocumentationParams, config
 from maykin_common.documentation.config_directives import (
     ConfigAllParamsDirective,
     ConfigGroupDirective,
@@ -38,7 +38,11 @@ def clean_registry():
 
 
 def test_config_param():
-    config("DISABLE_2FA", help_text="disable 2fa", default=False)
+    config(
+        "DISABLE_2FA",
+        default=False,
+        documentation=DocumentationParams(help_text="disable 2fa"),
+    )
 
     rst = textwrap.dedent("""
         .. config-param:: DISABLE_2FA
@@ -52,7 +56,11 @@ def test_config_param():
 
 
 def test_config_param_override_default():
-    config("DISABLE_2FA", help_text="disable 2fa", default=False)
+    config(
+        "DISABLE_2FA",
+        default=False,
+        documentation=DocumentationParams(help_text="disable 2fa"),
+    )
 
     rst = textwrap.dedent("""
         .. config-param:: DISABLE_2FA
@@ -69,9 +77,10 @@ def test_config_param_override_default():
 def test_config_param_do_not_display_default():
     config(
         "DISABLE_2FA",
-        help_text="disable 2fa",
         default=False,
-        auto_display_default=False,
+        documentation=DocumentationParams(
+            help_text="disable 2fa", auto_display_default=False
+        ),
     )
 
     rst = textwrap.dedent("""
@@ -87,7 +96,9 @@ def test_config_param_do_not_display_default():
 
 
 def test_config_param_default_empty_string():
-    config("SUBPATH", help_text="subpath", default="")
+    config(
+        "SUBPATH", default="", documentation=DocumentationParams(help_text="subpath")
+    )
 
     rst = textwrap.dedent("""
         .. config-param:: SUBPATH
@@ -117,7 +128,7 @@ def test_config_param_missing_help_text():
 def test_config_param_no_default(monkeypatch):
     monkeypatch.setenv("SOME_VAR", "foo")
 
-    config("SOME_VAR", help_text="some var")
+    config("SOME_VAR", documentation=DocumentationParams(help_text="some var"))
 
     rst = textwrap.dedent("""
         .. config-param:: SOME_VAR
@@ -145,8 +156,16 @@ def test_config_param_variable_does_not_exist(monkeypatch):
 
 
 def test_config_group():
-    config("DB_USER", help_text="db username.", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username.", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
 
     rst = textwrap.dedent("""
         .. config-group:: Database
@@ -163,8 +182,16 @@ def test_config_group():
 
 
 def test_config_group_cannot_use_members_groups_and_exclude_groups_together():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
 
     rst = textwrap.dedent("""
         .. config-group:: Database
@@ -177,14 +204,22 @@ def test_config_group_cannot_use_members_groups_and_exclude_groups_together():
 
 
 def test_config_group_do_not_add_var_to_docs():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
     config(
         "VAR_TO_IGNORE",
-        help_text="ignore",
-        group="Database",
         default="bar",
-        add_to_docs=False,
+        documentation=DocumentationParams(
+            help_text="ignore", group="Database", add_to_docs=False
+        ),
     )
 
     rst = textwrap.dedent("""
@@ -202,10 +237,26 @@ def test_config_group_do_not_add_var_to_docs():
 
 
 def test_config_group_members():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
-    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
-    config("PARAM_TO_EXCLUDE2", help_text="exclude", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE1",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude", group="Database"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE2",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude", group="Database"),
+    )
 
     rst = textwrap.dedent("""
         .. config-group:: Database
@@ -223,10 +274,26 @@ def test_config_group_members():
 
 
 def test_config_group_exclude_params():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
-    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
-    config("PARAM_TO_EXCLUDE2", help_text="exclude", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE1",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude", group="Database"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE2",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude", group="Database"),
+    )
 
     rst = textwrap.dedent("""
         .. config-group:: Database
@@ -249,16 +316,27 @@ def test_config_group_exclude_params():
 
 
 def test_config_all_params():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
     config(
         "ALLOWED_HOSTS",
-        help_text="allowed hosts",
-        group="Required",
         split=True,
         default="",
+        documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
 
     rst = textwrap.dedent("""
         .. config-all-params::
@@ -280,16 +358,27 @@ def test_config_all_params():
 
 
 def test_config_all_params_cannot_use_members_groups_and_exclude_groups_together():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
     config(
         "ALLOWED_HOSTS",
-        help_text="allowed hosts",
-        group="Required",
         split=True,
         default="",
+        documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
 
     rst = textwrap.dedent("""
         .. config-all-params::
@@ -302,19 +391,42 @@ def test_config_all_params_cannot_use_members_groups_and_exclude_groups_together
 
 
 def test_config_all_params_exclude_groups():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
     config(
         "ALLOWED_HOSTS",
-        help_text="allowed hosts",
-        group="Required",
         split=True,
         default="",
+        documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
-    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
-    config("PARAM_TO_EXCLUDE2", help_text="exclude", default="bar")
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE1",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude", group="Database"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE2",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude"),
+    )
 
     rst = textwrap.dedent("""
         .. config-all-params::
@@ -331,16 +443,27 @@ def test_config_all_params_exclude_groups():
 
 
 def test_config_all_params_members_groups():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
     config(
         "ALLOWED_HOSTS",
-        help_text="allowed hosts",
-        group="Required",
         split=True,
         default="",
+        documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
 
     rst = textwrap.dedent("""
         .. config-all-params::
@@ -361,12 +484,36 @@ def test_config_all_params_members_groups():
 
 
 def test_config_all_params_exclude_params():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
-    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
-    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
-    config("PARAM_TO_EXCLUDE2", help_text="exclude", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
+    config(
+        "SESSION_COOKIE_AGE",
+        default=1234,
+        documentation=DocumentationParams(help_text="session cookie age"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE1",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude", group="Database"),
+    )
+    config(
+        "PARAM_TO_EXCLUDE2",
+        default="bar",
+        documentation=DocumentationParams(help_text="exclude"),
+    )
 
     rst = textwrap.dedent("""
         .. config-all-params::
@@ -387,20 +534,28 @@ def test_config_all_params_exclude_params():
 
 
 def test_config_all_params_do_not_add_param_to_docs():
-    config("DB_USER", help_text="db username", group="Database", default="foo")
-    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "DB_USER",
+        default="foo",
+        documentation=DocumentationParams(help_text="db username", group="Database"),
+    )
+    config(
+        "DB_PASSWORD",
+        default="bar",
+        documentation=DocumentationParams(help_text="db password", group="Database"),
+    )
     config(
         "ALLOWED_HOSTS",
-        help_text="allowed hosts",
-        group="Required",
         split=True,
         default="",
+        documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
     config(
         "SESSION_COOKIE_AGE",
-        help_text="session cookie age",
         default=1234,
-        add_to_docs=False,
+        documentation=DocumentationParams(
+            help_text="session cookie age", add_to_docs=False
+        ),
     )
 
     rst = textwrap.dedent("""

--- a/tests/base/test_config_directives.py
+++ b/tests/base/test_config_directives.py
@@ -1,0 +1,421 @@
+import textwrap
+
+import pytest
+from docutils.core import publish_doctree
+from docutils.parsers.rst import directives
+
+import maykin_common.config
+from maykin_common.config import config
+from maykin_common.documentation.config_directives import (
+    ConfigAllParamsDirective,
+    ConfigGroupDirective,
+    ConfigParamDirective,
+)
+
+directives.register_directive("config-param", ConfigParamDirective)
+directives.register_directive("config-group", ConfigGroupDirective)
+directives.register_directive("config-all-params", ConfigAllParamsDirective)
+
+
+def parse_rst(rst: str) -> str:
+    document = publish_doctree(rst)
+    return document.astext()
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """
+    Make sure the envvar registry is reset between tests
+    """
+    maykin_common.config.ENVVAR_REGISTRY.clear()
+    yield
+    maykin_common.config.ENVVAR_REGISTRY.clear()
+
+
+#
+# Single parameter directive tests
+#
+
+
+def test_config_param():
+    config("DISABLE_2FA", help_text="disable 2fa", default=False)
+
+    rst = textwrap.dedent("""
+        .. config-param:: DISABLE_2FA
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = "* DISABLE_2FA: disable 2fa. Defaults to: False.<br>"
+
+    assert expected == doc
+
+
+def test_config_param_override_default():
+    config("DISABLE_2FA", help_text="disable 2fa", default=False)
+
+    rst = textwrap.dedent("""
+        .. config-param:: DISABLE_2FA
+            :default: True
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = "* DISABLE_2FA: disable 2fa. Defaults to: True.<br>"
+
+    assert expected == doc
+
+
+def test_config_param_do_not_display_default():
+    config(
+        "DISABLE_2FA",
+        help_text="disable 2fa",
+        default=False,
+        auto_display_default=False,
+    )
+
+    rst = textwrap.dedent("""
+        .. config-param:: DISABLE_2FA
+            :default: True
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = "* DISABLE_2FA: disable 2fa.<br>"
+
+    assert expected == doc
+
+
+def test_config_param_default_empty_string():
+    config("SUBPATH", help_text="subpath", default="")
+
+    rst = textwrap.dedent("""
+        .. config-param:: SUBPATH
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = "* SUBPATH: subpath. Defaults to: (empty string).<br>"
+
+    assert expected == doc
+
+
+def test_config_param_missing_help_text():
+    config("DISABLE_2FA", default=False)
+
+    rst = textwrap.dedent("""
+        .. config-param:: DISABLE_2FA
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = "* DISABLE_2FA:  Defaults to: False.<br>"
+
+    assert expected == doc
+
+
+def test_config_param_no_default(monkeypatch):
+    monkeypatch.setenv("SOME_VAR", "foo")
+
+    config("SOME_VAR", help_text="some var")
+
+    rst = textwrap.dedent("""
+        .. config-param:: SOME_VAR
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = "* SOME_VAR: some var.<br>"
+
+    assert expected == doc
+
+
+def test_config_param_variable_does_not_exist(monkeypatch):
+    rst = textwrap.dedent("""
+        .. config-param:: NON_EXISTENT_VAR
+    """)
+
+    with pytest.raises(ValueError):
+        parse_rst(rst)
+
+
+#
+# Config group directive tests
+#
+
+
+def test_config_group():
+    config("DB_USER", help_text="db username.", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+
+    rst = textwrap.dedent("""
+        .. config-group:: Database
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_group_cannot_use_members_groups_and_exclude_groups_together():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+
+    rst = textwrap.dedent("""
+        .. config-group:: Database
+            :members: DB_USER
+            :exclude: DB_PASSWORD
+    """)
+
+    with pytest.raises(ValueError):
+        parse_rst(rst)
+
+
+def test_config_group_do_not_add_var_to_docs():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "VAR_TO_IGNORE",
+        help_text="ignore",
+        group="Database",
+        default="bar",
+        add_to_docs=False,
+    )
+
+    rst = textwrap.dedent("""
+        .. config-group:: Database
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_group_members():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
+    config("PARAM_TO_EXCLUDE2", help_text="exclude", group="Database", default="bar")
+
+    rst = textwrap.dedent("""
+        .. config-group:: Database
+            :members: DB_USER, DB_PASSWORD
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_group_exclude_params():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
+    config("PARAM_TO_EXCLUDE2", help_text="exclude", group="Database", default="bar")
+
+    rst = textwrap.dedent("""
+        .. config-group:: Database
+            :exclude: PARAM_TO_EXCLUDE1, PARAM_TO_EXCLUDE2
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+    )
+
+    assert expected == doc
+
+
+#
+# All config params directive tests
+#
+
+
+def test_config_all_params():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "ALLOWED_HOSTS",
+        help_text="allowed hosts",
+        group="Required",
+        split=True,
+        default="",
+    )
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+
+    rst = textwrap.dedent("""
+        .. config-all-params::
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "Required\n\n"
+        "* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
+        "Database\n\n"
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>\n\n"
+        "Optional\n\n"
+        "* SESSION_COOKIE_AGE: session cookie age. Defaults to: 1234.<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_all_params_cannot_use_members_groups_and_exclude_groups_together():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "ALLOWED_HOSTS",
+        help_text="allowed hosts",
+        group="Required",
+        split=True,
+        default="",
+    )
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+
+    rst = textwrap.dedent("""
+        .. config-all-params::
+            :members-groups: Database
+            :exclude-groups: Required
+    """)
+
+    with pytest.raises(ValueError):
+        parse_rst(rst)
+
+
+def test_config_all_params_exclude_groups():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "ALLOWED_HOSTS",
+        help_text="allowed hosts",
+        group="Required",
+        split=True,
+        default="",
+    )
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
+    config("PARAM_TO_EXCLUDE2", help_text="exclude", default="bar")
+
+    rst = textwrap.dedent("""
+        .. config-all-params::
+            :exclude-groups: Database, Optional
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "Required\n\n* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_all_params_members_groups():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "ALLOWED_HOSTS",
+        help_text="allowed hosts",
+        group="Required",
+        split=True,
+        default="",
+    )
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+
+    rst = textwrap.dedent("""
+        .. config-all-params::
+            :members-groups: Database, Required
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "Required\n\n"
+        "* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
+        "Database\n\n"
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_all_params_exclude_params():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config("SESSION_COOKIE_AGE", help_text="session cookie age", default=1234)
+    config("PARAM_TO_EXCLUDE1", help_text="exclude", group="Database", default="bar")
+    config("PARAM_TO_EXCLUDE2", help_text="exclude", default="bar")
+
+    rst = textwrap.dedent("""
+        .. config-all-params::
+            :exclude-params: PARAM_TO_EXCLUDE1, PARAM_TO_EXCLUDE2
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "Database\n\n"
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>\n\n"
+        "Optional\n\n"
+        "* SESSION_COOKIE_AGE: session cookie age. Defaults to: 1234.<br>"
+    )
+
+    assert expected == doc
+
+
+def test_config_all_params_do_not_add_param_to_docs():
+    config("DB_USER", help_text="db username", group="Database", default="foo")
+    config("DB_PASSWORD", help_text="db password", group="Database", default="bar")
+    config(
+        "ALLOWED_HOSTS",
+        help_text="allowed hosts",
+        group="Required",
+        split=True,
+        default="",
+    )
+    config(
+        "SESSION_COOKIE_AGE",
+        help_text="session cookie age",
+        default=1234,
+        add_to_docs=False,
+    )
+
+    rst = textwrap.dedent("""
+        .. config-all-params::
+            :exclude-params: PARAM_TO_EXCLUDE1, PARAM_TO_EXCLUDE2
+    """)
+
+    doc = parse_rst(rst)
+
+    expected = (
+        "Required\n\n"
+        "* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
+        "Database\n\n"
+        "* DB_USER: db username. Defaults to: foo.<br>"
+        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+    )
+
+    assert expected == doc

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
   cli: celery
 skipsdist = True
 commands_pre =
-    django-admin compilemessages --verbosity 0
+    python -m django compilemessages --verbosity 0 --ignore ".tox/*"
 commands =
     pytest {env:TESTS} \
     -m 'not e2e' \
@@ -68,7 +68,7 @@ extras =
 deps =
     Django~=5.2.0
 commands_pre =
-    django-admin compilemessages --verbosity 0
+    python -m django compilemessages --verbosity 0 --ignore ".tox/*"
 commands =
     pytest tests -m 'e2e' \
     --ignore tests/pdf \


### PR DESCRIPTION
Closes https://github.com/maykinmedia/open-api-framework/issues/83 partially

Example in docs: https://open-klant--498.org.readthedocs.build/en/498/installation/config/env_configuration.html
