### PR TITLE
Port the `config` helper from default project + sort out type hinting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     tags:
       - '*'
   pull_request:
+  schedule:
+    - cron: "43 4 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -8,6 +8,8 @@ on:
     tags:
       - '*'
   pull_request:
+  schedule:
+    - cron: "43 4 * * *"
   workflow_dispatch:
 
 jobs:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -151,6 +151,11 @@ All modules in maykin-common either only require Django to be available, or requ
 optional dependencies. Optional modules have zero footprint as long as you don't import
 them, and when you do use them, ensure you've installed the appropriate extra.
 
+Reading settings from the environment
+-------------------------------------
+
+Use the :func:`maykin_common.config.config` helper.
+
 API projects (team bron)
 ------------------------
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -1,0 +1,9 @@
+.. _reference_configuration:
+
+=====================
+Project configuration
+=====================
+
+.. automodule:: maykin_common.config
+    :members:
+    :undoc-members:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -11,6 +11,7 @@ Python API reference.
    :caption: Core utilities
 
    checks
+   configuration
    context_processors
    migration_operations
    views

--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -1,0 +1,115 @@
+"""
+Utilities to read and process configuration for a project.
+
+.. todo:: Incorporate the Team Bron documentation options for parameters.
+"""
+
+from collections.abc import Callable, Sequence
+from typing import Literal, assert_never, overload
+
+from decouple import Csv, Undefined, config as _config, undefined
+
+__all__ = ["config"]
+
+
+@overload
+def config(option: str) -> str: ...
+
+
+@overload
+def config[T](
+    option: str, *, default: Sequence[T] | Undefined = undefined, split: Literal[True]
+) -> list[T]: ...
+
+
+@overload
+def config[T](option: str, *, default: T | Undefined = undefined) -> T: ...
+
+
+@overload
+def config[U](
+    option: str, *, default: object = undefined, cast: Callable[[str], U]
+) -> U: ...
+
+
+def config[T, U](
+    option: str,
+    *,
+    default: T | None | Undefined = undefined,
+    split: bool = False,
+    cast: Callable[[str], U] | Undefined = undefined,
+) -> str | None | T | Sequence[T] | U:
+    """
+    Pull a config parameter from the environment.
+
+    Read the config variable ``option``. If it's optional, use the ``default`` value.
+
+    If not ``cast`` parameter is provided, then the ``cast`` is derived from the
+    ``default`` type when a default is provided. However, when you provide a ``cast``
+    parameter explicitly, you must provide any ``default`` as a string as it will be
+    passed to the provided ``cast`` callback.
+
+    Note that ``default=None`` does not mean there's no default - omit the kwarg
+    entirely instead.
+
+    Pass ``split=True`` to split the comma-separated input into a list. If a default is
+    provided, it must be a list.
+
+    Examples::
+
+        >>> SECRET_KEY: str = config("SECRET_KEY")
+        >>> DB_NAME: str = config("DB_NAME", default="my-awesome-project")
+        >>> DB_PORT: int = config("DB_PORT", default=5432")
+        >>> SESSION_COOKIE_DOMAIN: str | None = config(
+        ...     "SESSION_COOKIE_DOMAIN", default=None
+        ... )
+        >>> ALLOWED_HOSTS: list[str] = config("ALLOWED_HOSTS", split=True, default=[])
+        >>> CUSTOM = config(
+        ...     "CUSTOM",
+        ...     default="123",
+        ...     cast=lambda v: int(v) if v is not None else None,
+        ... )  # typed as int | None
+    """
+
+    if split:
+        assert isinstance(default, Undefined | Sequence), (
+            "You must provide a sequence default argument"
+        )
+        match default:
+            case Sequence():
+                # python-decouple Csv cast expects the default as a string -
+                # serialize it again.
+                return _config(option, cast=Csv(), default=",".join(default))
+            case _:
+                return _config(option, cast=Csv())
+
+    # infer the ``cast`` from the default if not provided explicitly
+    match (cast, default):
+        #
+        # cases without explicit cast
+        #
+        case Undefined(), Undefined():
+            return _config(option)
+        case Undefined(), None:
+            # explicit `None` default values cannot be used as cast, ignore it.
+            return _config(option, default=default)
+        case Undefined(), _:
+            return _config(option, default=default, cast=type(default))
+        #
+        # with explicit cast
+        #
+        case _, Undefined():
+            return _config(option, cast=cast)
+        case _, _:
+            # the combination of a default + cast is odd and goes against the common
+            # behaviour when it's derived from the default type - unfortunately we can't
+            # simply take the ``str(default)``, as there's no guarantee that
+            # ``default == cast(str(default))`` (e.g. ``cast=date.fromisoformat``
+            # already falls apart)
+            if not isinstance(default, str):
+                raise TypeError(
+                    "'default' must be a string when providing a cast callback"
+                )
+            return _config(option, default=default, cast=cast)
+        case _:  # pragma: no cover
+            assert_never((cast, default))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "django>=4.2"
+    "django>=4.2",
+    "python-decouple",
 ]
 
 [project.urls]
@@ -49,6 +50,7 @@ tests = [
     "ruff",
     "pyright",
     "django-stubs",
+    "decouple-types",
     "celery",
 ]
 docs = [

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -95,3 +95,8 @@ def test_read_unset_setting_with_custom_cast_fallback_to_default():
     )
 
     assert result == date(2025, 1, 1)
+
+
+def test_raise_typeerror_when_non_string_default_is_specified_together_with_cast():
+    with pytest.raises(TypeError):
+        config("SOME_OPTIONAL_SETTING", default=123, cast=lambda x: x)

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -1,0 +1,97 @@
+"""
+Tests for the config helper.
+
+The pytest tests themselves test the behaviour of the utility, while the type
+annotations in the tests are validated by pyright and check that the type overloads are
+set up as expected.
+"""
+
+from datetime import date
+
+import decouple
+import pytest
+
+from maykin_common.config import config
+
+
+def test_read_unset_and_required_setting_without_default():
+    with pytest.raises(decouple.UndefinedValueError):
+        config("SOME_REQUIRED_SETTING")
+
+
+def test_read_provided_and_required_setting_without_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("SOME_REQUIRED_SETTING", "expected-result")
+
+    result: str = config("SOME_REQUIRED_SETTING")
+
+    assert result == "expected-result"
+
+
+def test_read_unset_setting_fallback_to_default():
+    result: int = config("SOME_OPTIONAL_SETTING", default=42)
+
+    assert result == 42
+
+
+def test_read_provided_setting_without_fallback_to_default_and_auto_cast(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("SOME_OPTIONAL_SETTING", "67")
+
+    result: int = config("SOME_OPTIONAL_SETTING", default=42)
+
+    assert result == 67
+
+
+def test_read_setting_with_None_default():
+    result: str | None = config("SOME_OPTIONAL_SETTING", default=None)
+
+    assert result is None
+
+
+def test_read_unset_list_setting_fallback_to_default():
+    result: list[str] = config(
+        "SOME_OPTIONAL_COMMA_SEPARATED_LIST", default=["default"], split=True
+    )
+
+    assert result == ["default"]
+
+
+def test_read_provided_list_setting_without_fallback_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("SOME_OPTIONAL_COMMA_SEPARATED_LIST", "first, second")
+
+    result: list[str] = config(
+        "SOME_OPTIONAL_COMMA_SEPARATED_LIST", default=["default"], split=True
+    )
+
+    assert result == ["first", "second"]
+
+
+def test_read_provided_list_setting_without_default(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SOME_REQUIRED_COMMA_SEPARATED_LIST", "first,second")
+
+    result: list[str] = config("SOME_REQUIRED_COMMA_SEPARATED_LIST", split=True)
+
+    assert result == ["first", "second"]
+
+
+def test_read_provided_setting_with_custom_cast(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("SOME_OPTIONAL_SETTING", "2025-12-25")
+
+    result: date = config("SOME_OPTIONAL_SETTING", cast=date.fromisoformat)
+
+    assert result == date(2025, 12, 25)
+
+
+def test_read_unset_setting_with_custom_cast_fallback_to_default():
+    result: date = config(
+        "SOME_OPTIONAL_SETTING",
+        default="2025-01-01",
+        cast=date.fromisoformat,
+    )
+
+    assert result == date(2025, 1, 1)


### PR DESCRIPTION
Partly closes #7

This is an alternative implementation to #34, without the documentation generation aspect which I'd like to decouple (lol).