### PR TITLE
instrument db, redis, celery and requests (otel)

### DIFF
--- a/docs/otel.rst
+++ b/docs/otel.rst
@@ -30,8 +30,6 @@ Open Telemetry has *things to say* about all this data.
    persisted in some monitoring backend. In the future, we will include the helpers for
    this in maykin-common.
 
-.. note:: Tracing is set up, but not fully fleshed out yet.
-
 
 Quickstart (tl;dr)
 ==================
@@ -150,6 +148,52 @@ Defining and using a metric is pretty straightforward:
 
     Other packages that we maintain can also opt-in to defining and tracking metrics in
     the future.
+
+
+Tracing
+-------
+
+:func:`maykin_common.otel.setup_otel` calls opentelemetry instrumentors which automatically
+add traces for Django requests, Redis and PostgreSQL queries, Celery tasks and external HTTP
+requests performed with the ``requests`` library.
+
+It's also possible to add manual spans for any part of the code.
+Opentelemetry provides a context manager ``tracer.start_as_current_span`` for it:
+
+.. code-block:: python
+   :linenos:
+
+    from opentelemetry import trace
+
+    tracer = trace.get_tracer("my_awesome_project.my_module")
+
+
+    def do_work():
+        print("doing work outside of the span")
+
+        with tracer.start_as_current_span("span-name") as span:
+            print("doing some work, that span will track")
+
+        print("doing more work outside of the span")
+
+
+It's also possible to use ``tracer.start_as_current_span`` as a decorator:
+
+.. code-block:: python
+   :linenos:
+
+    from opentelemetry import trace
+
+    tracer = trace.get_tracer("my_awesome_project.my_module")
+
+
+    @tracer.start_as_current_span("span-name")
+    def do_work():
+        print("doing some work, that span will track")
+
+Opentelemetry documentation provides more `examples <https://opentelemetry.io/docs/languages/python/instrumentation/#creating-spans>`_
+how to create spans.
+
 
 .. _otel_best_practices:
 

--- a/docs/otel.rst
+++ b/docs/otel.rst
@@ -191,7 +191,7 @@ It's also possible to use ``tracer.start_as_current_span`` as a decorator:
     def do_work():
         print("doing some work, that span will track")
 
-Opentelemetry documentation provides more `examples <https://opentelemetry.io/docs/languages/python/instrumentation/#creating-spans>`_
+The Opentelemetry documentation provides more `examples <https://opentelemetry.io/docs/languages/python/instrumentation/#creating-spans>`_
 how to create spans.
 
 

--- a/maykin_common/otel.py
+++ b/maykin_common/otel.py
@@ -23,6 +23,7 @@ from django.utils.module_loading import import_string
 
 from opentelemetry import metrics, trace
 from opentelemetry.instrumentation.django import DjangoInstrumentor
+from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
 from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
@@ -78,9 +79,10 @@ def setup_otel() -> None:
     # wrappers/middleware etc.
 
     # the instrumentor is a singleton, so it's effectively global
-    instrumentor = DjangoInstrumentor()
-    if not instrumentor.is_instrumented_by_opentelemetry:
-        instrumentor.instrument()
+    instrumentors = [DjangoInstrumentor(), PsycopgInstrumentor()]
+    for instrumentor in instrumentors:
+        if not instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.instrument()
 
     # In some situations (similar to uwsgi, see below), initialization must be deferred,
     # e.g. in celery workers with a process pool that fork other processes. Detecting

--- a/maykin_common/otel/__init__.py
+++ b/maykin_common/otel/__init__.py
@@ -1,0 +1,5 @@
+from .setup import setup_otel
+
+__all__ = [
+    "setup_otel",
+]

--- a/maykin_common/otel/processors.py
+++ b/maykin_common/otel/processors.py
@@ -3,9 +3,9 @@ from opentelemetry.sdk.trace import Span, SpanProcessor
 
 
 class CustomAttributeSpanProcessor(SpanProcessor):
-    def on_start(self, span: "Span", parent_context: Context | None = None) -> None:
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         """
-        Determine type and subtype based on instrumentation library
+        Determine type and subtype based on the active instrumentation library.
         """
         if span.attributes and span.attributes.get("span.type"):
             return

--- a/maykin_common/otel/processors.py
+++ b/maykin_common/otel/processors.py
@@ -15,33 +15,32 @@ class CustomAttributeSpanProcessor(SpanProcessor):
             instrumentation_scope.name.lower() if instrumentation_scope else ""
         )
 
-        if "redis" in library_name:
-            span_type = "db"
-            span_subtype = "redis"
+        span_type: str
+        span_subtype: str
 
-        elif "psycopg" in library_name:
-            span_type = "db"
-            span_subtype = "postgresql"
-
-        elif "django" in library_name:
-            span_type = (
-                "web"
-                if span.attributes and span.attributes.get("http.method")
-                else "app"
-            )
-            span_subtype = "django"
-
-        elif "requests" in library_name:
-            span_type = "external"
-            span_subtype = "http"
-
-        elif "celery" in library_name:
-            span_type = "async"
-            span_subtype = "celery"
-
-        else:
-            span_type = "unknown"
-            span_subtype = "unknown"
+        match library_name:
+            case "opentelemetry.instrumentation.redis":
+                span_type = "db"
+                span_subtype = "redis"
+            case "opentelemetry.instrumentation.psycopg":
+                span_type = "db"
+                span_subtype = "postgresql"
+            case "opentelemetry.instrumentation.django":
+                span_type = (
+                    "web"
+                    if span.attributes and span.attributes.get("http.method")
+                    else "app"
+                )
+                span_subtype = "django"
+            case "opentelemetry.instrumentation.requests":
+                span_type = "external"
+                span_subtype = "http"
+            case "opentelemetry.instrumentation.celery":
+                span_type = "async"
+                span_subtype = "celery"
+            case _:
+                span_type = "unknown"
+                span_subtype = "unknown"
 
         span.set_attribute("span.type", span_type)
         span.set_attribute("span.subtype", span_subtype)

--- a/maykin_common/otel/processors.py
+++ b/maykin_common/otel/processors.py
@@ -1,4 +1,3 @@
-
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import Span, SpanProcessor
 

--- a/maykin_common/otel/processors.py
+++ b/maykin_common/otel/processors.py
@@ -1,3 +1,4 @@
+
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import Span, SpanProcessor
 

--- a/maykin_common/otel/processors.py
+++ b/maykin_common/otel/processors.py
@@ -24,7 +24,11 @@ class CustomAttributeSpanProcessor(SpanProcessor):
             span_subtype = "postgresql"
 
         elif "django" in library_name:
-            span_type = "web" if span.attributes.get("http.method") else "app"
+            span_type = (
+                "web"
+                if span.attributes and span.attributes.get("http.method")
+                else "app"
+            )
             span_subtype = "django"
 
         elif "requests" in library_name:

--- a/maykin_common/otel/processors.py
+++ b/maykin_common/otel/processors.py
@@ -1,0 +1,43 @@
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import Span, SpanProcessor
+
+
+class CustomAttributeSpanProcessor(SpanProcessor):
+    def on_start(self, span: "Span", parent_context: Context | None = None) -> None:
+        """
+        Determine type and subtype based on instrumentation library
+        """
+        if span.attributes and span.attributes.get("span.type"):
+            return
+
+        instrumentation_scope = span.instrumentation_scope
+        library_name = (
+            instrumentation_scope.name.lower() if instrumentation_scope else ""
+        )
+
+        if "redis" in library_name:
+            span_type = "db"
+            span_subtype = "redis"
+
+        elif "psycopg" in library_name:
+            span_type = "db"
+            span_subtype = "postgresql"
+
+        elif "django" in library_name:
+            span_type = "web" if span.attributes.get("http.method") else "app"
+            span_subtype = "django"
+
+        elif "requests" in library_name:
+            span_type = "external"
+            span_subtype = "http"
+
+        elif "celery" in library_name:
+            span_type = "async"
+            span_subtype = "celery"
+
+        else:
+            span_type = "unknown"
+            span_subtype = "unknown"
+
+        span.set_attribute("span.type", span_type)
+        span.set_attribute("span.subtype", span_subtype)

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -24,6 +24,7 @@ from django.utils.module_loading import import_string
 from opentelemetry import metrics, trace
 from opentelemetry.instrumentation.celery import CeleryInstrumentor
 from opentelemetry.instrumentation.django import DjangoInstrumentor
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
 from opentelemetry.instrumentation.redis import RedisInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
@@ -59,6 +60,14 @@ type ExportProtocol = Literal["grpc", "http/protobuf"]
 
 DEFAULT_PROTOCOL: ExportProtocol = "grpc"
 
+INSTRUMENTORS: list[BaseInstrumentor] = [
+    DjangoInstrumentor(),
+    PsycopgInstrumentor(),
+    CeleryInstrumentor(),
+    RedisInstrumentor(),
+    RequestsInstrumentor(),
+]
+
 
 def setup_otel() -> None:
     """
@@ -82,14 +91,7 @@ def setup_otel() -> None:
     # wrappers/middleware etc.
 
     # the instrumentor is a singleton, so it's effectively global
-    instrumentors = [
-        DjangoInstrumentor(),
-        PsycopgInstrumentor(),
-        CeleryInstrumentor(),
-        RedisInstrumentor(),
-        RequestsInstrumentor(),
-    ]
-    for instrumentor in instrumentors:
+    for instrumentor in INSTRUMENTORS:
         if not instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.instrument()
 

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -37,8 +37,8 @@ from opentelemetry.sdk.resources import (
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from .config import config
-from .settings import get_setting
+from ..config import config
+from ..settings import get_setting
 
 # the uwsgi module is special - it's only available when the python code is loaded
 # through uwsgi. With regular ``manage.py`` usage, it does not exist.

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -40,9 +40,10 @@ from opentelemetry.sdk.resources import (
 )
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from .processors import CustomAttributeSpanProcessor
+
 from ..config import config
 from ..settings import get_setting
+from .processors import CustomAttributeSpanProcessor
 
 # the uwsgi module is special - it's only available when the python code is loaded
 # through uwsgi. With regular ``manage.py`` usage, it does not exist.

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -22,8 +22,11 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.module_loading import import_string
 
 from opentelemetry import metrics, trace
+from opentelemetry.instrumentation.celery import CeleryInstrumentor
 from opentelemetry.instrumentation.django import DjangoInstrumentor
 from opentelemetry.instrumentation.psycopg import PsycopgInstrumentor
+from opentelemetry.instrumentation.redis import RedisInstrumentor
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
 from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_PROTOCOL
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
@@ -79,7 +82,13 @@ def setup_otel() -> None:
     # wrappers/middleware etc.
 
     # the instrumentor is a singleton, so it's effectively global
-    instrumentors = [DjangoInstrumentor(), PsycopgInstrumentor()]
+    instrumentors = [
+        DjangoInstrumentor(),
+        PsycopgInstrumentor(),
+        CeleryInstrumentor(),
+        RedisInstrumentor(),
+        RequestsInstrumentor(),
+    ]
     for instrumentor in instrumentors:
         if not instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.instrument()

--- a/maykin_common/otel/setup.py
+++ b/maykin_common/otel/setup.py
@@ -39,7 +39,7 @@ from opentelemetry.sdk.resources import (
 )
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
+from .processors import CustomAttributeSpanProcessor
 from ..config import config
 from ..settings import get_setting
 
@@ -147,8 +147,9 @@ def _setup_otel() -> None:
     OTLPMetricExporter, OTLPSpanExporter = load_exporters()
 
     tracer_provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(OTLPSpanExporter())
-    tracer_provider.add_span_processor(processor)
+    batch_processor = BatchSpanProcessor(OTLPSpanExporter())
+    tracer_provider.add_span_processor(batch_processor)
+    tracer_provider.add_span_processor(CustomAttributeSpanProcessor())
     trace.set_tracer_provider(tracer_provider)
 
     reader = PeriodicExportingMetricReader(OTLPMetricExporter())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ otel = [
     "opentelemetry-exporter-otlp",
     "opentelemetry-instrumentation-django",
     "opentelemetry-instrumentation-psycopg",
+    "opentelemetry-instrumentation-redis",
+    "opentelemetry-instrumentation-requests",
+    "opentelemetry-instrumentation-celery",
     "opentelemetry-resource-detector-containerid",
     "opentelemetry-sdk",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ otel = [
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",
     "opentelemetry-instrumentation-django",
+    "opentelemetry-instrumentation-psycopg",
     "opentelemetry-resource-detector-containerid",
     "opentelemetry-sdk",
 ]

--- a/tests/otel/test_otel_init.py
+++ b/tests/otel/test_otel_init.py
@@ -16,18 +16,18 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
     OTLPSpanExporter as HttpOTLPSpanExporter,
 )
-from opentelemetry.instrumentation.django import DjangoInstrumentor
 from opentelemetry.metrics import NoOpMeterProvider, set_meter_provider
 from opentelemetry.sdk.metrics.export import MetricExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace.export import SpanExporter
 from opentelemetry.trace import NoOpTracerProvider, set_tracer_provider
 
-from maykin_common.otel import (
+from maykin_common.otel import setup_otel
+from maykin_common.otel.setup import (
+    INSTRUMENTORS,
     ExportProtocol,
     aggregate_resource,
     load_exporters,
-    setup_otel,
 )
 
 
@@ -48,7 +48,8 @@ def _reset_otel():
     if hasattr(meter_provider, "shutdown"):
         meter_provider.shutdown()  # pyright: ignore[reportAttributeAccessIssue]
 
-    DjangoInstrumentor().uninstrument()
+    for instrumentor in INSTRUMENTORS:
+        instrumentor.uninstrument()
 
     # reset to noop
     set_tracer_provider(NoOpTracerProvider())
@@ -103,7 +104,7 @@ def test_initializer_can_run_multiple_times_without_problems(
 def test_deferring_setup_via_envvar(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("_OTEL_DEFER_SETUP", "True")
 
-    with patch("maykin_common.otel._setup_otel") as mock_setup_otel:
+    with patch("maykin_common.otel.setup._setup_otel") as mock_setup_otel:
         setup_otel()
 
     mock_setup_otel.assert_not_called()
@@ -113,7 +114,7 @@ def test_failing_celery_import_does_not_raise(monkeypatch: pytest.MonkeyPatch):
     def raise_importerror(*args, **kwargs):
         raise ImportError("Can't be imported")
 
-    monkeypatch.setattr("maykin_common.otel.import_string", raise_importerror)
+    monkeypatch.setattr("maykin_common.otel.setup.import_string", raise_importerror)
 
     try:
         setup_otel()

--- a/tests/otel/test_otel_init.py
+++ b/tests/otel/test_otel_init.py
@@ -24,7 +24,7 @@ from opentelemetry.trace import NoOpTracerProvider, set_tracer_provider
 
 from maykin_common.otel import setup_otel
 from maykin_common.otel.setup import (
-    INSTRUMENTORS,
+    PACKAGE_INSTRUMENTOR_MAPPING,
     ExportProtocol,
     aggregate_resource,
     load_exporters,
@@ -48,8 +48,8 @@ def _reset_otel():
     if hasattr(meter_provider, "shutdown"):
         meter_provider.shutdown()  # pyright: ignore[reportAttributeAccessIssue]
 
-    for instrumentor in INSTRUMENTORS:
-        instrumentor.uninstrument()
+    for instrumentor in PACKAGE_INSTRUMENTOR_MAPPING.values():
+        instrumentor().uninstrument()
 
     # reset to noop
     set_tracer_provider(NoOpTracerProvider())

--- a/tests/otel/test_otel_processor.py
+++ b/tests/otel/test_otel_processor.py
@@ -1,0 +1,75 @@
+import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from maykin_common.otel.processors import CustomAttributeSpanProcessor
+
+
+@pytest.fixture
+def span_exporter():
+    return InMemorySpanExporter()
+
+
+@pytest.fixture(autouse=True)
+def reset_span_exporter(span_exporter):
+    """Automatically clear span exporter after each test"""
+    yield
+    span_exporter.clear()
+
+
+def test_processor_redis(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(CustomAttributeSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    # Create tracer with redis instrumentation scope
+    tracer = provider.get_tracer("opentelemetry.instrumentation.redis")
+
+    with tracer.start_as_current_span("redis.get"):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    span = spans[0]
+
+    assert span.attributes.get("span.type") == "db"
+    assert span.attributes.get("span.subtype") == "redis"
+
+
+def test_processor_django(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(CustomAttributeSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    tracer = provider.get_tracer("opentelemetry.instrumentation.django")
+
+    with tracer.start_as_current_span("GET /forms", attributes={"http.method": "GET"}):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    span = spans[0]
+
+    assert span.attributes.get("span.type") == "web"
+    assert span.attributes.get("span.subtype") == "django"
+
+
+def test_processor_custom(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(CustomAttributeSpanProcessor())
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    tracer = provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span(
+        "custom_operation",
+        attributes={"span.type": "custom-type", "span.subtype": "custom-subtype"},
+    ):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+    span = spans[0]
+
+    assert span.attributes.get("span.type") == "custom-type"
+    assert span.attributes.get("span.subtype") == "custom-subtype"


### PR DESCRIPTION
fixes https://github.com/open-formulieren/open-forms/issues/5450 (partly)

**Tried options to instrument database:**

1. `opentelemetry-instrument` (https://opentelemetry.io/docs/zero-code/python/configuration/) command
   uses `sitecustomize` module which initialize all available instrumentors, but it doesn't see the environment variables
   (especially `DJANGO_SETUP_MODULE`), and I couldn't make it work both with `uwsgi` and `runserver`
2. I want to reuse this auto-instrument code from `opentelemetry-instrument` command, mainly loading of all
   available instrumentors. So I added it to the `setup_otel` function. I kept only loading and initializing of instrumentators, since the configuration (Resource, meterProvidor, traceProvider) is added manually in the `_setup_otel`
3. I want also to note, that I've tried to add loading and initializing of instrumentors in the `setup_otel` function, but in this case `DjangoInstrumentor` didn't work, but `PsycopgInstrumentator` did work. Unfortunately I couldn't figure out the reason why it happens

**UPD.** After discussion it was decided to use manual import of instrumentators, which gives more control and adds less magic to the code