### PR TITLE
Add health checks to monitor celery beat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+      # For celery integration tests with a real broker
+      redis:
+        image: redis:8
+        ports:
+          - 6379:6379
 
     steps:
       - name: Install OS packages

--- a/docs/health_checks.rst
+++ b/docs/health_checks.rst
@@ -1,0 +1,120 @@
+.. _health-checks:
+
+=============
+Health checks
+=============
+
+Health checks are used to mark (crashed) containers as unhealthy, so that they can be
+restarted by the container orchestration (Kubernetes, Docker engine...).
+
+The health check tooling in maykin-common covers the HTTP health checks for the Django
+app and the Celery components, like the worker and beat.
+
+.. versionadded:: 0.13.0
+
+    Added tooling for Django health checks.
+
+.. versionadded:: 0.14.0
+
+    Added support for Celery.
+
+.. contents:: Jump to
+    :local:
+    :depth: 2
+
+There is also :ref:`reference documentation <reference_health_checks>` available.
+
+Quickstart (tl;dr)
+==================
+
+Install the extra dependencies:
+
+.. code-block:: bash
+
+    uv pip install maykin-common[cli,health-checks]
+
+Update your settings accordingly:
+
+.. code-block:: python
+
+    from maykin_common.health_checks import (
+        default_health_check_apps,
+        default_health_check_subsets,
+    )
+
+    INSTALLED_APPS = [
+        ...,
+        *default_health_check_apps,
+        ...
+    ]
+
+    HEALTH_CHECK = {
+        "SUBSETS": default_health_check_subsets,
+    }
+
+and your root ``urls.py``:
+
+.. code-block:: python
+
+    urlpatterns = [
+        ...,
+        path("", include("maykin_common.health_checks.urls")),
+        ...,
+    ]
+
+Command line
+============
+
+You can use the ``maykin-common cli`` to probe the health check endpoint(s):
+
+.. code-block:: bash
+
+    maykin-common health-check --endpoint=/_healthz/livez/
+
+Which will exit with exit code ``0`` for success responses (HTTP status code between 200
+and 399).
+
+.. note:: Make sure the install the ``cli`` extra:
+
+    .. code-block:: bash
+
+        uv pip install maykin-common[cli]
+
+Celery
+======
+
+If you use Celery in your project, there are health check tools for the Celery
+components too.
+
+Beat
+----
+
+We can monitor Beat's liveness by tracking when was the last time a task was scheduled.
+Instrumentation is done by adding a Django app and (optionally) specifying the file path
+to the liveness file:
+
+.. code-block:: python
+
+    from pathlib import Path
+
+    INSTALLED_APPS = [
+        ...,
+        "maykin_common.health_checks.celery",
+        ...
+    ]
+
+    MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE = Path("/tmp/celery_beat_live")
+
+The file specified through ``MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE`` will be touched
+every time Beat successfully schedules a task to the broker. The health check can then
+test how long ago the file was last touched. For example, if your Beat schedule runs a
+task every hour, you could run the health check that expects the file to be modified
+less than 2 hours ago.
+
+.. tip:: If your normal schedule has very infrequent tasks (e.g. once per week), you
+   may want to set up a smoke test task that runs more frequently (e.g. every hour).
+
+Worker
+------
+
+.. todo:: To be implemented.

--- a/docs/health_checks.rst
+++ b/docs/health_checks.rst
@@ -65,7 +65,10 @@ and your root ``urls.py``:
 Command line
 ============
 
-You can use the ``maykin-common cli`` to probe the health check endpoint(s):
+HTTP health checks
+------------------
+
+You can use the ``maykin-common`` CLI to probe the health check endpoint(s):
 
 .. code-block:: bash
 
@@ -79,6 +82,26 @@ and 399).
     .. code-block:: bash
 
         uv pip install maykin-common[cli]
+
+Celery beat health checks
+-------------------------
+
+If you use Celery Beat and install the health checks (see below), you can test the
+Beat liveness too:
+
+.. code-block:: bash
+
+    maykin-common beat-health-check --file /app/tmp/celery/beat.live --max-age 120
+
+Which will exit with exit code ``0`` if the specified file exists and is last modified
+within the specified number of seconds. The file path should match the value of the
+``MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE`` setting.
+
+.. tip:: Use a ``--max-age`` that's 2x the interval of your most frequently scheduled
+   task. E.g. if you have a task that runs every minute, pick 120 seconds.
+
+.. tip:: Use startup probes if possible to give Beat time to load, start and schedule
+   a task for the first time.
 
 Celery
 ======

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ Features
    :caption: Contents:
 
    quickstart
+   health_checks
    otel
    apis
    settings

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -90,49 +90,6 @@ reset path to your existing ``urlpatterns``.
 
 .. _quickstart_pdf:
 
-Health checks
--------------
-
-Install command:
-
-.. code-block:: bash
-
-    uv pip install maykin-common[cli,health-checks]
-
-Used for programmatic Docker/Kubernetes health checks, which restart containers when the
-app appears to have crashed.
-
-Update your settings accordingly:
-
-.. code-block:: python
-
-    from maykin_common.health_checks import (
-        default_health_check_apps,
-        default_health_check_subsets,
-    )
-
-    INSTALLED_APPS = [
-        ...,
-        *default_health_check_apps,
-        ...
-    ]
-
-    HEALTH_CHECK = {
-        "SUBSETS": default_health_check_subsets,
-    }
-
-and your root ``urls.py``:
-
-.. code-block:: python
-
-    urlpatterns = [
-        ...,
-        path("", include("maykin_common.health_checks.urls")),
-        ...,
-    ]
-
-For more details, see :ref:`reference_health_checks`.
-
 PDF
 ---
 
@@ -198,6 +155,11 @@ Reading settings from the environment
 -------------------------------------
 
 Use the :func:`maykin_common.config.config` helper.
+
+Health checks
+-------------
+
+See :ref:`health-checks` on how to setup health checks.
 
 API projects (team bron)
 ------------------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -159,7 +159,7 @@ Use the :func:`maykin_common.config.config` helper.
 Health checks
 -------------
 
-See :ref:`health-checks` on how to setup health checks.
+See :ref:`health_checks` on how to setup health checks.
 
 API projects (team bron)
 ------------------------

--- a/docs/reference/health_checks.rst
+++ b/docs/reference/health_checks.rst
@@ -37,24 +37,6 @@ return an HTTP status code ``200`` if all is well, and ``500`` otherwise.
     and configure a higher failure treshold for the liveness probe to allow the
     application to recover before restarting it.
 
-Command line
-============
-
-You can use the ``maykin-common cli`` to probe the health check endpoint(s):
-
-.. code-block:: bash
-
-    maykin-common health-check --endpoint=/_healthz/livez/
-
-Which will exit with exit code ``0`` for success responses (HTTP status code between 200
-and 399).
-
-.. note:: Make sure the install the ``cli`` extra:
-
-    .. code-block:: bash
-
-        uv pip install maykin-common[cli]
-
 Django setting defaults
 =======================
 
@@ -79,3 +61,18 @@ The setting defaults should be imported from :mod:`maykin_common.health_checks`:
 
 .. automodule:: maykin_common.health_checks.defaults
     :members:
+
+Celery
+======
+
+.. automodule:: maykin_common.health_checks.celery.apps
+    :members:
+
+.. automodule:: maykin_common.health_checks.celery.probes
+    :members:
+    :undoc-members:
+
+Settings
+--------
+
+* :attr:`maykin_common.settings.MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE`

--- a/maykin_common/cli.py
+++ b/maykin_common/cli.py
@@ -26,15 +26,24 @@ def version():
     typer.echo(f"maykin-common v{version}")
 
 
-@app.command(
-    name="health-check",
-    help=(
-        "Execute an HTTP health check call against the provided endpoint. If no "
-        "host or domain is provided in the endpoint, this will default to "
-        "'http://localhost:8000'."
-    ),
-)
-def health_check(endpoint: str = "/_healthz/livez/", timeout: int = 3):
+@app.command(name="health-check")
+def health_check(
+    endpoint: Annotated[
+        str,
+        typer.Option(help="Endpoint/path to test for connection and status code."),
+    ] = "/_healthz/livez/",
+    timeout: Annotated[
+        int,
+        typer.Option(help="Timeout for the GET request (in seconds)."),
+    ] = 3,
+):
+    """
+    Execute an HTTP health check call against the provided endpoint.
+
+    If no host or domain is provided with the ``endpoint`` option, a default of
+    ``http://localhost:8000`` will be used.
+    """
+
     # URLs must start with a scheme, otherwise urlparse chokes :-)
     if not (endpoint.startswith("http://") or endpoint.startswith("https://")):
         endpoint = f"http://{endpoint}"

--- a/maykin_common/cli.py
+++ b/maykin_common/cli.py
@@ -1,4 +1,17 @@
+"""
+Command line companion to the ``maykin-common`` Django utilities.
+
+The command line script is deliberately written in pure Python without loading Django
+at all (for performance), as opposed to providing Django management commands. Large
+Django projects may see slow startup times in the order of 2-10s due to (expensive)
+imports when loading all the code. This pairs very badly with health checks machinery
+which tend to have timeouts of a couple of seconds.
+"""
+
 import importlib.metadata
+import time
+from pathlib import Path
+from typing import Annotated
 from urllib.parse import urlparse, urlunparse
 
 import requests
@@ -58,6 +71,64 @@ def health_check(endpoint: str = "/_healthz/livez/", timeout: int = 3):
 
     exit_code = 0 if up else 1
     exit(exit_code)
+
+
+@app.command(name="beat-health-check")
+def beat_health_check(
+    file: Annotated[
+        Path,
+        typer.Option(
+            help="The liveness file, created and updated by the Beat health check "
+            "machinery."
+        ),
+    ] = Path("/tmp") / "celery_beat_live",
+    max_age: Annotated[
+        int,
+        typer.Option(
+            help="How long ago the last update of liveness file is allowed to be, in "
+            "seconds. You should tune this to the beat schedule of your application."
+        ),
+    ] = 3600,
+):
+    """
+    Check the last modified timestamp of the Beat liveness file.
+
+    If it's older than ``max-age``, Beat is considered unhealthy.
+    """
+    file = file.resolve()
+    if not file.exists() or not file.is_file():
+        typer.secho(
+            f"File '{file}' does not exist or is not a file.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        exit(1)
+
+    # check the file age
+    now = time.time()
+    last_modified = file.stat().st_mtime
+    age_in_seconds = int(now - last_modified)
+    if age_in_seconds > max_age:
+        typer.secho(
+            f"File '{file}' is older than max-age.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        exit(1)
+    else:
+        human_readable_age: str = f"{age_in_seconds}s"
+        if 60 < age_in_seconds < 3600:
+            age_in_minutes = round(age_in_seconds / 60, 1)
+            human_readable_age = f"{age_in_minutes:.1f}m".replace(".0", "")
+        elif age_in_seconds >= 3600:
+            age_in_hours = round(age_in_seconds / 3600, 1)
+            human_readable_age = f"{age_in_hours:.1f}h".replace(".0", "")
+
+        typer.secho(
+            f"Last scheduled task: {human_readable_age} ago.",
+            fg=typer.colors.GREEN,
+        )
+        exit(0)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/maykin_common/health_checks/celery/__init__.py
+++ b/maykin_common/health_checks/celery/__init__.py
@@ -1,0 +1,6 @@
+import importlib.util
+
+from django.core.exceptions import ImproperlyConfigured
+
+if importlib.util.find_spec("celery") is None:  # pragma: no cover
+    raise ImproperlyConfigured("You must install celery to use celery health checks.")

--- a/maykin_common/health_checks/celery/apps.py
+++ b/maykin_common/health_checks/celery/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+from .probes import connect_beat_signals
+
+
+class CeleryHealthChecksAppConfig(AppConfig):
+    name = "maykin_common.health_checks.celery"
+
+    def ready(self):
+        connect_beat_signals()

--- a/maykin_common/health_checks/celery/probes.py
+++ b/maykin_common/health_checks/celery/probes.py
@@ -1,0 +1,57 @@
+import atexit
+import logging
+from pathlib import Path
+
+from celery.beat import Service as BeatService
+from celery.signals import after_task_publish, beat_init
+
+from maykin_common.settings import get_setting
+
+logger = logging.getLogger(__name__)
+
+#
+# Utilities for checking the health of celery beat
+#
+
+_RUNNING_IN_BEAT = False
+
+
+def on_beat_init(*, sender: BeatService, **kwargs):
+    global _RUNNING_IN_BEAT
+    _RUNNING_IN_BEAT = True
+    logger.debug("beat_process_marked")
+    liveness_file: Path = get_setting("MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE")
+    # on shutdown, clear up the liveness file
+    atexit.register(liveness_file.unlink, missing_ok=True)
+
+
+def on_beat_task_published(*, sender: str, routing_key: str, **kwargs):
+    """
+    Update the celery beat liveness every time a task is successfully published.
+
+    ``after_task_publish`` fires in the process that sent the task, so we must discern
+    between the regular Django app that schedules tasks, and celery beat that also
+    schedules tasks. We do this by tapping into the ``beat_init`` signal to mark the
+    process as a beat process, and only touch the liveness file when running in beat.
+    """
+    if not _RUNNING_IN_BEAT:
+        return
+
+    liveness_file: Path = get_setting("MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE")
+    logger.debug(
+        "beat_task_published", extra={"task": sender, "routing_key": routing_key}
+    )
+    # create intermediate directories if they don't yet exist
+    if not (parent_dir := liveness_file.parent).exists():
+        parent_dir.mkdir(parents=True, exist_ok=True)
+    # touching the file updates the last modified timestamp, which can be checked by
+    # the health-check command
+    liveness_file.touch()
+
+
+def connect_beat_signals():
+    # register signals for beat so that we can health-check it
+    beat_init.connect(on_beat_init, dispatch_uid="probes.on_beat_init")
+    after_task_publish.connect(
+        on_beat_task_published, dispatch_uid="probes.on_beat_task_published"
+    )

--- a/maykin_common/settings.py
+++ b/maykin_common/settings.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal
 
 from django.conf import settings
@@ -62,6 +63,17 @@ This setting is used in the :func:`maykin_common.views.csrf_failure` view to han
 errors that occur when attempting to log in a second time.
 """
 
+MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE: Path = Path("/tmp") / "celery_beat_live"
+"""
+Path to the file that acts as a liveness marker of Celery Beat.
+
+Used when :mod:`maykin_common.health_checks.celery` is installed, which registers health
+check mechanisms for Celery Beat. The intermediate directories will be created if
+absent. The file itself will be created when beat publishes its first task, and will
+be unlinked again when beat exits.
+"""
+
+
 type SettingName = Literal[
     "GOOGLE_ANALYTICS_ID",
     "ENVIRONMENT",
@@ -73,6 +85,7 @@ type SettingName = Literal[
     "GIT_SHA",
     "PDF_BASE_URL_FUNCTION",
     "LOGIN_URLS",
+    "MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ tests = [
     "django-stubs",
     "decouple-types",
     "celery",
+    "redis",
 ]
 docs = [
     "sphinx",
@@ -103,6 +104,7 @@ DJANGO_SETTINGS_MODULE = "testapp.settings"
 markers = [
     "e2e: mark tests as end-to-end tests, using playwright (deselect with '-m \"not e2e\"')",
     "vcr: mark inferred from pytest-django @tag(\"vcr\") on a test case",
+    "beat_liveness_file: options for the celery beat liveness fixture",
 ]
 
 [tool.bumpversion]
@@ -118,6 +120,7 @@ files = [
 [tool.coverage.run]
 branch = true
 source = ["maykin_common"]
+patch = ["subprocess"]
 omit = [
     # migrations run while django initializes the test db
     "*/migrations/*",

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse_lazy
 
+from maykin_common.config import config
+
 try:
     import axes
 except ImportError:
@@ -105,3 +107,12 @@ CSRF_FAILURE_VIEW = "maykin_common.views.csrf_failure"
 HEALTH_CHECK = {
     "SUBSETS": default_health_check_subsets,
 }
+
+#
+# CUSTOM health check settings
+#
+MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE: Path = config(
+    "MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE",
+    default="/tmp/celery_beat_live",
+    cast=Path,
+)

--- a/tests/cli/test_beat_health_check_command.py
+++ b/tests/cli/test_beat_health_check_command.py
@@ -1,0 +1,99 @@
+import os
+import time
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from maykin_common.cli import app
+
+runner = CliRunner()
+
+
+def test_health_check_defaults():
+    default_path_exists = (Path("/tmp") / "celery_beat_live").is_file()
+    assert not default_path_exists  # establish pre-condition for test
+
+    result = runner.invoke(app, ["beat-health-check"])
+
+    assert result.exit_code == 1
+
+
+def test_health_check_file_is_not_a_file():
+    result = runner.invoke(
+        app,
+        [
+            "beat-health-check",
+            "--file",
+            "/",
+        ],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_health_check_file_is_a_file_but_too_old(tmp_path: Path):
+    test_file = tmp_path / "test"
+    test_file.touch()
+    result = runner.invoke(
+        app,
+        [
+            "beat-health-check",
+            "--file",
+            str(test_file),
+            "--max-age",
+            "-1",  # abuse the fact that negative integers can be specified
+        ],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_health_check_file_is_a_file_and_young_enough(tmp_path: Path):
+    test_file = tmp_path / "test"
+    test_file.touch()
+    result = runner.invoke(
+        app,
+        [
+            "beat-health-check",
+            "--file",
+            str(test_file),
+            "--max-age",
+            "10",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "age,expected",
+    (
+        (30, "30s ago"),
+        (300, "5m ago"),
+        (330, "5.5m ago"),
+        (3600, "1h ago"),
+        (3600 + 1799, "1.5h ago"),
+        (3600 * 10, "10h ago"),
+    ),
+)
+def test_output_formatting_of_file_age(tmp_path: Path, age: int, expected: str):
+    test_file = tmp_path / "test"
+    test_file.touch()  # create the file
+    creation_time = mod_time = time.time() - age
+    # modify the creation/modification timestamps
+    os.utime(test_file, (creation_time, mod_time))
+
+    result = runner.invoke(
+        app,
+        [
+            "beat-health-check",
+            "--file",
+            str(test_file),
+            "--max-age",
+            str(age + 60),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert expected in result.stdout

--- a/tests/health_checks/test_celery_beat_health_checks.py
+++ b/tests/health_checks/test_celery_beat_health_checks.py
@@ -1,0 +1,172 @@
+# Celery is specified in the test dependencies already for the otel instrumentation, so
+# we can rely on it being available for health-check tests.
+
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from celery import Celery
+
+from maykin_common.health_checks.celery.probes import (
+    connect_beat_signals,
+    on_beat_task_published,
+)
+
+ROOT_DIR = Path(__file__).parent.parent.parent.resolve()
+
+app = Celery("maykin-common-tests", broker="redis://localhost:6379/0")
+# signals must be connected in the process that runs beat - this module is imported
+# again via the start_beat_process fixture which starts a subprocess
+connect_beat_signals()
+
+app.conf.beat_schedule = {
+    "dummy": {
+        "task": "tests.health_checks.test_celery_beat_health_checks.dummy",
+        "schedule": 1.0,  # every second, for sufficiently fast tests.
+    }
+}
+
+
+@app.task()
+def dummy():
+    """
+    Dummy task for beat schedule.
+    """
+    return "ok"
+
+
+@pytest.fixture(autouse=True)
+def install_celery_health_checks(settings):
+    settings.INSTALLED_APPS = [
+        *settings.INSTALLED_APPS,
+        "maykin_common.health_checks.celery.apps.CeleryHealthChecksAppConfig",
+    ]
+
+
+@pytest.fixture
+def beat_liveness_file(request, tmp_path: Path) -> Path:
+    marker = request.node.get_closest_marker("beat_liveness_file")
+    subpath = marker.kwargs.get("subpath") if marker else ""
+    dir_path = tmp_path
+    if subpath:
+        dir_path /= subpath
+    return dir_path / "beat_live"
+
+
+@pytest.fixture
+def start_beat_process(beat_liveness_file):
+    """
+    Start a subprocess running beat and stop it when the test exits.
+    """
+    assert not beat_liveness_file.exists(), "beat liveness file should not yet exist"
+
+    cmd = [
+        "celery",
+        "--workdir",
+        str(ROOT_DIR),
+        "--app",
+        __name__,
+        "beat",
+        "--loglevel",
+        "CRITICAL",
+    ]
+    env = os.environ.copy()
+    env["MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE"] = str(beat_liveness_file)
+
+    # start the process and let it run in the background - it should not exit by itself.
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    try:
+        yield proc
+    finally:
+        is_running = proc.poll() is None
+        if not is_running:
+            return  # noqa: B012
+        proc.terminate()
+        proc.wait(timeout=5)
+
+
+def _wait_until(
+    predicate: Callable[[], bool], *, timeout: float, interval: float = 0.1
+):
+    """
+    Poll predicate() until it returns True or timeout expires.
+    Returns True if condition met, False if timed out.
+    """
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+
+    raise AssertionError("Predicate was never satisfied")
+
+
+def test_beat_hooks_create_heartbeat_file(
+    start_beat_process: subprocess.Popen[bytes],
+    beat_liveness_file: Path,
+):
+    """
+    Check that when beat is running and scheduling tasks, it touches a heartheat file.
+    """
+    _wait_until(beat_liveness_file.exists, timeout=5)
+
+    assert beat_liveness_file.is_file()
+
+
+def test_beat_updates_file_stat(
+    start_beat_process: subprocess.Popen[bytes],
+    beat_liveness_file: Path,
+):
+    # start up beat and wait until the liveness file is initially created
+    _wait_until(beat_liveness_file.exists, timeout=5)
+    initial_modified = beat_liveness_file.stat().st_mtime
+
+    # check that the modified at timestamp is updated because of hour every-second
+    # task
+    _wait_until(
+        lambda: beat_liveness_file.stat().st_mtime - initial_modified > 1, timeout=3
+    )
+
+
+def test_beat_removes_liveness_file_on_exit(
+    start_beat_process: subprocess.Popen[bytes],
+    beat_liveness_file: Path,
+):
+    _wait_until(beat_liveness_file.exists, timeout=5)
+
+    start_beat_process.terminate()
+    start_beat_process.wait(timeout=5)
+
+    assert not beat_liveness_file.exists()
+
+
+def test_no_liveness_file_created_when_not_running_in_beat(beat_liveness_file: Path):
+    assert not beat_liveness_file.exists()
+
+    on_beat_task_published(sender="mock", routing_key="mock")
+
+    assert not beat_liveness_file.exists()
+
+
+@pytest.mark.beat_liveness_file(subpath="subpath-to-create")
+def test_intermediate_directories_are_created(
+    start_beat_process: subprocess.Popen[bytes],
+    tmp_path: Path,
+    beat_liveness_file: Path,
+):
+    _wait_until(beat_liveness_file.exists, timeout=5)
+
+    assert beat_liveness_file.relative_to(tmp_path) == Path(
+        "subpath-to-create/beat_live"
+    )
+    assert beat_liveness_file.is_file()

--- a/tests/health_checks/test_celery_beat_health_checks.py
+++ b/tests/health_checks/test_celery_beat_health_checks.py
@@ -42,7 +42,7 @@ def dummy():
 def install_celery_health_checks(settings):
     settings.INSTALLED_APPS = [
         *settings.INSTALLED_APPS,
-        "maykin_common.health_checks.celery.apps.CeleryHealthChecksAppConfig",
+        "maykin_common.health_checks.celery",
     ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -94,6 +94,7 @@ extras =
     tests
     docs
     health-checks
+    celery
 allowlist_externals = make
 commands_pre =
 commands=
@@ -111,6 +112,7 @@ extras =
     vcr
     otel
     health-checks
+    celery
     cli
 commands_pre =
 commands = pyright


### PR DESCRIPTION
Partly closes #48

- [x] Implement heartbeat file/marker
- [x] Test beat marker
- [x] Document beat settings/marker (installation + setting)
- [x] Implement health check CLI command (provide --max-age argument, default to 1h)

Command line output samples:

<img width="815" height="148" alt="image" src="https://github.com/user-attachments/assets/3487b78c-25c6-4e2a-be9b-4558d8471f29" />
