### PR TITLE
Implement Celery Worker health check tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: pip install tox tox-gh-actions
 
       - name: Run tests
-        run: tox
+        run: tox --colored=yes
         env:
           PYTHON_VERSION: ${{ matrix.python }}
           DJANGO: ${{ matrix.django }}

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -35,7 +35,7 @@ jobs:
           python-version-file: "pyproject.toml"
       - name: Install dependencies
         run: pip install tox
-      - run: tox
+      - run: tox --colored=yes
         env:
           TOXENV: ${{ matrix.toxenv }}
           FORCE_COLOR: '1'

--- a/docs/health_checks.rst
+++ b/docs/health_checks.rst
@@ -63,6 +63,15 @@ and your root ``urls.py``:
         ...,
     ]
 
+and in your ``celery.py`` entrypoint:
+
+.. code-block:: python
+
+    from maykin_common.health_checks.celery.probes import EventLoopProbe
+
+    app = Celery("my-proj")
+    app.steps["worker"].add(EventLoopProbe)
+
 See the :ref:`health_checks_cli` details for how to test the health.
 
 Celery
@@ -101,12 +110,111 @@ less than 2 hours ago.
 
 .. caution::
 
-   If you use the :class:`django_celery_beat.schedulers.DatabaseScheduler` scheduler, you should be aware that your schedules are editable at runtime through the admin, which may mean your ``max-age`` parameter no longer aligns with your actual schedule, leading to erroneously failed health checks. In such cases you might want to consider scheduling an explicit heartbeat task, using the task description to make clear that the task should be enabled and should not be re-scheduled.
+   If you use the :class:`django_celery_beat.schedulers.DatabaseScheduler` scheduler,
+   you should be aware that your schedules are editable at runtime through the admin,
+   which may mean your ``max-age`` parameter no longer aligns with your actual schedule,
+   leading to erroneously failed health checks. In such cases you might want to consider
+   scheduling an explicit heartbeat task, using the task description to make clear that
+   the task should be enabled and should not be re-scheduled.
 
 Worker
 ------
 
-.. todo:: To be implemented.
+Monitoring Celery Worker's health is complicated due to the complex nature of workers
+and how they can fail. The worker system essentially boots up a whole stack of
+subsystems that can each fail and contribute to "broken" workers. For details, see the
+`blueprints <https://docs.celeryq.dev/en/stable/userguide/extending.html#blueprints>`_
+docs.
+
+**Enabling the checks**
+
+Enabling the worker health check machinery requires some small changes to your
+configuration.
+
+First, ensure the settings are configured appropriately:
+
+.. code-block:: python
+
+    from pathlib import Path
+
+    INSTALLED_APPS = [
+        ...,
+        "maykin_common.health_checks.celery",
+        ...
+    ]
+
+    # optional settings, the defaults are listed
+    MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS = 60
+    MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE = Path("/tmp") / "celery_worker_event_loop_live"
+    MKN_HEALTH_CHECKS_WORKER_READINESS_FILE = Path("/tmp") / "celery_worker_ready"
+
+
+This installs the signal receiver for the worker ready/shutdown, wich affects the
+presence of ``MKN_HEALTH_CHECKS_WORKER_READINESS_FILE``.
+
+Next, in your Celery entrypoint (where you define ``app = Celery("my-celery-app")``),
+add the bootstep:
+
+.. code-block:: python
+    :linenos:
+    :emphasize-lines: 1,4
+
+    from maykin_common.health_checks.celery.probes import EventLoopProbe
+
+    app = Celery("my-project")
+    app.steps["worker"].add(EventLoopProbe)
+    app.autodiscover_tasks()
+
+Which sets up the event-loop monitoring and affects the last-modified timestamp of the
+``MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE``.
+
+**Background information**
+
+The health-check tooling we ship hooks into some critical phases:
+
+#. Worker starts
+#. Event loop is started, including the timer <-- we hook into the timer to check the
+   event loop
+#. Consumer starts
+#. Consumer establishes broker connection <-- we test the connection by pinging
+#. Consumer starts consuming tasks
+#. Consumer is ready to process tasks <-- we hook into this signal
+
+Celery's machinery is set up so that the whole consumer subsystem restarts on connection
+loss, which should make it recover gracefully without restarting the whole worker
+process.
+
+**What we monitor**
+
+* Event loop liveness. Periodically, we touch a heartbeat file that shows the event loop
+  is still live and able to orchestrate work. The frequency can be tweaked with the
+  ``MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS`` setting.
+* Broker connection health, by sending a PING roundtrip from the worker process to
+  itself. This is reliable (especially with the default preforking pool) because the
+  ping control machinery lives in the main process, not in the worker processes that
+  actually execute tasks, so it cannot be blocked by long-running tasks.
+* Worker readiness - a readiness file is created when the worker is ready to start
+  processing tasks. It is deleted again when the worker shuts down.
+
+**What we don't monitor**
+
+* Actual tasks execution - while it's possible in theory to create a worker-specific
+  queue
+  and schedule a task from itself to the worker, this brings a lot of additional
+  uncertainty and complexity:
+
+    * the task can be held up by other long-running tasks, because it will execute in a
+      worker process
+    * the queue name must contain the worker (host) name, which creates many keys in the
+      broker. For brokers like Redis, these keys don't automatically expire and pollute
+      the system. So, a periodic task and additional machinery are needed to detect stale
+      exchanges and clean them up.
+
+* Desired concurrency is available. Some tests showed that Celery seems perfectly
+  capable of restarting crashed processes and maintains the desired number of worker
+  processes. Unless this becomes an observed failure mode, these sort of things will not
+  be added.
+
 
 .. _health_checks_cli:
 
@@ -134,7 +242,7 @@ and 399).
 Celery beat health checks
 -------------------------
 
-If you use Celery Beat and install the health checks (see below), you can test the
+If you use Celery Beat and install the health checks (see above), you can test the
 Beat liveness too:
 
 .. code-block:: bash
@@ -150,3 +258,108 @@ within the specified number of seconds. The file path should match the value of 
 
 .. tip:: Use startup probes if possible to give Beat time to load, start and schedule
    a task for the first time.
+
+Celery worker health checks
+---------------------------
+
+If you use Celery and install the health checks (see above), you can test their health:
+
+.. code-block:: bash
+
+    maykin-common worker-health-check \
+        --no-skip-event-loop-liveness \
+        --liveness-file /tmp/celery_worker_event_loop_live \
+        --max-age 70 \
+        --no-skip-ping \
+        --broker redis://localhost:6379/0 \
+        --worker-name celery@localhost \
+        --ping-timeout 3 \
+        --skip-readiness
+
+The example options closely match the defaults.
+
+.. tip:: Ensure you invoke this command in the worker container itself.
+
+.. tip:: Use startup probes if possible to give the worker time to load, create the
+   health check files and establish a broker connection.
+
+The command tests different aspects and will exit with a non-zero exit code when any of
+the tests fails.
+
+Event loop liveness
+~~~~~~~~~~~~~~~~~~~
+
+Default: enabled.
+
+The event loop liveness test checks that the last modified timestamp of
+``--liveness-file`` is not older than ``--max-age``. If the event loop/timer crashes,
+then the liveness file will not be touched any more and eventually become older than
+the provided max age.
+
+By default, the event loop file is touched every minute, so the default max age accounts
+for some potential time drift.
+
+Ping
+~~~~
+
+Default: enabled.
+
+The ping roundtrip sends a ping from the worker to itself, which travels via the broker
+connection. Ping failures detect potential broker connection issues which definitely
+result in the worker not being able to pick up results.
+
+The ping check requires some routing information.
+
+``--broker``
+    The address of the broker, matching the ``CELERY_BROKER`` setting. Ping needs to
+    connect to the broker to send the control message. In container contexts, you will
+    typically use a service or container name, e.g. ``redis://my-redis:6379/0/`` that
+    uses DNS resolution.
+
+    .. tip:: The ``localhost`` default points to the container itself. Make sure to
+       provide this option explicitly.
+
+``--worker-name``
+    The worker name is taken from the envvar ``CELERY_WORKER_NAME`` if set. In
+    containerized environments, the worker name usually has the shape ``<queue>@<host>``,
+    where the default queue is usually named ``celery``, but projects can define
+    dedicated queues/workers for queues.
+
+    The host name is usually taken from the container ``hostname`` and matches either
+    the container name on Docker engine or the pod name on Kubernetes.
+
+    Example worker names:
+
+    * ``celery@sparky``
+    * ``celery@my-project-client-test-celery-1``
+    * ``long-running@my-project-client-test-celery-1``
+    * ``celery@celery-worker-554b9c67f9-c5cv4``
+
+.. note::
+
+    Ping requires some additional information to keep the health check lightweight
+    without loading the entire application in memory, as that itself can take multiple
+    seconds and can fail probe timeouts.
+
+Readiness
+~~~~~~~~~
+
+Default: disabled.
+
+The readiness test checks that the readiness file exists. It is created when the worker
+signals that it's ready to start processing tasks, at the end of the startup phase. It
+is deleted when the worker shuts down.
+
+Absence of the readiness file can indicate that the worker failed to load the
+application code. On Kubernetes with rolling deployments, you probably want to add this
+as a readiness probe to prevent old pods from being stopped when the new version is
+broken.
+
+Recommended usage in a readiness probe:
+
+    .. code-block:: bash
+
+        maykin-common worker-health-check \
+            --skip-event-loop-liveness \
+            --skip-ping \
+            --readiness-file /tmp/celery_worker_ready

--- a/maykin_common/cli.py
+++ b/maykin_common/cli.py
@@ -126,7 +126,7 @@ def worker_health_check(
         ),
     ] = f"celery@{socket.gethostname()}",
     ping_timeout: Annotated[
-        int, typer.Option(help="Timeout after which the ping check fails.")
+        int, typer.Option(help="Timeout in seconds after which the ping check fails.")
     ] = 3,
     skip_ping: Annotated[
         bool, typer.Option(help="Opt-out from the ping roundtrip check.")
@@ -138,7 +138,7 @@ def worker_health_check(
             help="The readiness file, created when the worker is ready to process "
             "tasks."
         ),
-    ] = Path("/tmp") / "celery_worker_event_loop_live",
+    ] = Path("/tmp") / "celery_worker_ready",
     skip_readiness: Annotated[
         bool, typer.Option(help="Opt-in to the readiness check.")
     ] = True,

--- a/maykin_common/health_checks/celery/apps.py
+++ b/maykin_common/health_checks/celery/apps.py
@@ -1,10 +1,11 @@
 from django.apps import AppConfig
 
-from .probes import connect_beat_signals
+from .probes import connect_beat_signals, connect_worker_signals
 
 
 class CeleryHealthChecksAppConfig(AppConfig):
     name = "maykin_common.health_checks.celery"
 
     def ready(self):
+        connect_worker_signals()
         connect_beat_signals()

--- a/maykin_common/health_checks/celery/probes.py
+++ b/maykin_common/health_checks/celery/probes.py
@@ -1,13 +1,91 @@
 import atexit
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+from celery import bootsteps
+from celery.apps.worker import Worker as _Worker
 from celery.beat import Service as BeatService
 from celery.signals import after_task_publish, beat_init
+from kombu.asynchronous.timer import Entry as TimerEntry, Timer
 
 from maykin_common.settings import get_setting
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+
+    class Worker(_Worker):
+        """
+        Worker class with timer attribute.
+
+        Assigned through :meth:`celery.worker.components.Timer.create`, it's a dynamic
+        attribute that's not present in the base class definitions, so we have to
+        massage it a bit.
+        """
+
+        timer: Timer
+else:
+    Worker = _Worker
+
+
+#
+# Utilities for checking the health of celery worker
+#
+
+EVENT_LOOP_PROBE_FREQUENCY_SECONDS = 60.0
+
+
+class EventLoopProbe(bootsteps.StartStopStep):
+    """
+    Checks that the Celery worker event loop is alive.
+
+    When the Celery worker starts, it starts the event loop, timer and processing pool.
+    As a "final" step, it starts the Consumer blueprint, which is responsible for
+    establishing the broker connection and actually start processing/consuming messages
+    and tasks.
+
+    This event loop probe installs a boostep when the timer is available, and schedules
+    a periodic callback that touches a liveness file. If the timestamp of the last
+    modified moment of the liveness file is too long again, we can conclude/assume that
+    the event loop has crashed and the worker should be restarted, as it's likely that
+    ETA/countdown tasks and tasks in general are not being processed anymore by this
+    worker. This makes no guarantees about actually being able to consume tasks or a
+    live connection though. The timer runs in the main worker process (when using
+    the preforking/multi-processing pool).
+
+    Celery itself *should* re-establish broker connection on connection loss, by
+    restarting the Consumer blueprint, but bugs in Celery itself have been observed in
+    the past. We can implement connectivity checks by pinging the worker from itself,
+    which is set up elsewhere.
+
+    See the `upstream <https://docs.celeryq.dev/en/stable/userguide/extending.html#blueprints>`_
+    documentation for details about blueprints and bootstep mechanisms.
+    """
+
+    # we need the Timer component before we can run this bootstep. Celery uses this to
+    # figure out the step dependency graph.
+    requires = {"celery.worker.components:Timer"}
+    tref: TimerEntry | None = None
+    liveness_file: Path
+
+    def start(self, parent: Worker):
+        self.liveness_file = get_setting(
+            "MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE"
+        )
+        # create intermediate directories if they don't yet exist
+        if not (parent_dir := self.liveness_file.parent).exists():
+            parent_dir.mkdir(parents=True, exist_ok=True)
+
+        self.tref = parent.timer.call_repeatedly(
+            EVENT_LOOP_PROBE_FREQUENCY_SECONDS,
+            self.liveness_file.touch,
+            priority=10,
+        )
+
+    def stop(self, parent: Worker):
+        self.liveness_file.unlink(missing_ok=True)
+
 
 #
 # Utilities for checking the health of celery beat

--- a/maykin_common/health_checks/celery/probes.py
+++ b/maykin_common/health_checks/celery/probes.py
@@ -44,7 +44,7 @@ class EventLoopProbe(bootsteps.StartStopStep):
     establishing the broker connection and actually start processing/consuming messages
     and tasks.
 
-    This event loop probe installs a boostep when the timer is available, and schedules
+    This event loop probe installs a bootstep when the timer is available, and schedules
     a periodic callback that touches a liveness file. If the timestamp of the last
     modified moment of the liveness file is too long again, we can conclude/assume that
     the event loop has crashed and the worker should be restarted, as it's likely that

--- a/maykin_common/settings.py
+++ b/maykin_common/settings.py
@@ -73,6 +73,19 @@ absent. The file itself will be created when beat publishes its first task, and 
 be unlinked again when beat exits.
 """
 
+MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE: Path = (
+    Path("/tmp") / "celery_worker_event_loop_live"
+)
+"""
+Path to the file that acts as a liveness marker of the Celery Worker event loop.
+
+Used when the :class:`maykin_common.health_checks.celery.probes.EventLoopProbe` is added
+as a Celery Worker bootstep, which periodically updates the liveness file with the last
+timer tick. The intermediate directories will be created if absent. The file itself will
+be created when the worker main process starts, and will be unlinked again when the
+worker exits.
+"""
+
 
 type SettingName = Literal[
     "GOOGLE_ANALYTICS_ID",
@@ -86,6 +99,7 @@ type SettingName = Literal[
     "PDF_BASE_URL_FUNCTION",
     "LOGIN_URLS",
     "MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE",
+    "MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE",
 ]
 
 

--- a/maykin_common/settings.py
+++ b/maykin_common/settings.py
@@ -85,6 +85,7 @@ timer tick. The intermediate directories will be created if absent. The file its
 be created when the worker main process starts, and will be unlinked again when the
 worker exits.
 """
+
 MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS: int = 60
 """
 Frequency in seconds on how often the event loop should update the liveness file.

--- a/maykin_common/settings.py
+++ b/maykin_common/settings.py
@@ -85,7 +85,23 @@ timer tick. The intermediate directories will be created if absent. The file its
 be created when the worker main process starts, and will be unlinked again when the
 worker exits.
 """
+MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS: int = 60
+"""
+Frequency in seconds on how often the event loop should update the liveness file.
+"""
 
+MKN_HEALTH_CHECKS_WORKER_READINESS_FILE: Path = Path("/tmp") / "celery_worker_ready"
+"""
+Path to the file that acts as a readiness marker of Celery Worker.
+
+Used when :mod:`maykin_common.health_checks.celery` is installed, which registers health
+check mechanisms for Celery Worker. The intermediate directories will be created if
+absent. The file itself will be created when the worker is ready to accept work, i.e.
+once the consumer blueprint is finished as part of the celery worker startup. It means
+that a connection with the broker is established and tasks can be processed.
+
+When the worker shuts down, the file is unlinked.
+"""
 
 type SettingName = Literal[
     "GOOGLE_ANALYTICS_ID",
@@ -100,6 +116,8 @@ type SettingName = Literal[
     "LOGIN_URLS",
     "MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE",
     "MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE",
+    "MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS",
+    "MKN_HEALTH_CHECKS_WORKER_READINESS_FILE",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,8 @@ markers = [
     "e2e: mark tests as end-to-end tests, using playwright (deselect with '-m \"not e2e\"')",
     "vcr: mark inferred from pytest-django @tag(\"vcr\") on a test case",
     "beat_liveness_file: options for the celery beat liveness fixture",
+    "worker_event_loop_liveness_file: options for the celery worker liveness fixture",
+    "worker_readiness_file: options for the celery worker readiness fixture",
 ]
 
 [tool.bumpversion]

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -115,3 +115,20 @@ MKN_HEALTH_CHECKS_BEAT_LIVENESS_FILE: Path = config(
     default="/tmp/celery_beat_live",
     cast=Path,
 )
+
+MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE = config(
+    "MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE",
+    default="/tmp/celery_worker_live",
+    cast=Path,
+)
+
+MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS = config(
+    "MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS",
+    default=60,
+)
+
+MKN_HEALTH_CHECKS_WORKER_READINESS_FILE = config(
+    "MKN_HEALTH_CHECKS_WORKER_READINESS_FILE",
+    default="/tmp/celery_worker_ready",
+    cast=Path,
+)

--- a/tests/cli/test_worker_health_check_command.py
+++ b/tests/cli/test_worker_health_check_command.py
@@ -1,0 +1,275 @@
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from celery import Celery
+from typer.testing import CliRunner
+
+from maykin_common.cli import (
+    _WORKER_EXIT_CODE_EVENT_LOOP_BROKEN,
+    _WORKER_EXIT_CODE_NOT_READY,
+    _WORKER_EXIT_CODE_PING_FAILURE,
+    app,
+)
+
+ROOT_DIR = Path(__file__).parent.parent.parent.resolve()
+
+runner = CliRunner()
+
+celery_app = Celery("maykin-common-tests", broker="redis://localhost:6379/0")
+
+
+@pytest.fixture
+def start_worker_process():
+    """
+    Start a subprocess running worker and stop it when the test exits.
+    """
+    cmd = [
+        "celery",
+        "--workdir",
+        str(ROOT_DIR),
+        "--app",
+        f"{__name__}:celery_app",
+        "worker",
+        "--hostname",
+        "celery@test",
+        "--loglevel",
+        "DEBUG",
+        "-c",
+        "1",
+    ]
+
+    # start the process and let it run in the background - it should not exit by itself.
+    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        yield proc
+    finally:
+        is_running = proc.poll() is None
+        if not is_running:
+            return  # noqa: B012
+        proc.terminate()
+        # allow sufficient shutdown time, as workers have hot/cold shutdowns
+        proc.wait(timeout=10)
+
+
+def _wait_until(
+    predicate: Callable[[], bool], *, timeout: float, interval: float = 0.1
+):
+    """
+    Poll predicate() until it returns True or timeout expires.
+    Returns True if condition met, False if timed out.
+    """
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+
+    raise AssertionError("Predicate was never satisfied")
+
+
+def test_health_check_all_parts_disabled():
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--skip-event-loop-liveness",
+            "--skip-ping",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+
+#
+# EVENT LOOP LIVENESS
+#
+
+
+def test_event_loop_liveness_is_not_a_file():
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--liveness-file",
+            "/",
+            "--skip-ping",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == _WORKER_EXIT_CODE_EVENT_LOOP_BROKEN
+
+
+def test_event_loop_liveness_is_a_file_but_too_old(tmp_path: Path):
+    test_file = tmp_path / "test"
+    test_file.touch()
+
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--liveness-file",
+            str(test_file),
+            "--max-age",
+            "-1",  # abuse the fact that negative integers can be specified
+            "--skip-ping",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == _WORKER_EXIT_CODE_EVENT_LOOP_BROKEN
+
+
+def test_event_loop_liveness_is_a_file_and_young_enough(tmp_path: Path):
+    test_file = tmp_path / "test"
+    test_file.touch()
+
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--liveness-file",
+            str(test_file),
+            "--max-age",
+            "10",
+            "--skip-ping",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+
+#
+# PING
+#
+
+
+def _ping_ready():
+    replies = celery_app.control.ping(destination=["celery@test"], timeout=1)
+    return bool(replies)
+
+
+def test_ping_fails_no_worker_running():
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--no-skip-ping",
+            "--ping-timeout",
+            "1",
+            "--skip-event-loop-liveness",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == _WORKER_EXIT_CODE_PING_FAILURE
+
+
+def test_ping_running_worker(start_worker_process: subprocess.Popen):
+    _wait_until(_ping_ready, timeout=10)
+
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--no-skip-ping",
+            "--worker-name",
+            "celery@test",
+            "--broker",
+            "redis://localhost:6379/0",
+            "--ping-timeout",
+            "5",
+            "--skip-event-loop-liveness",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+
+def test_ping_fails_wrong_worker_name(start_worker_process: subprocess.Popen):
+    _wait_until(_ping_ready, timeout=10)
+
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--no-skip-ping",
+            "--worker-name",
+            "WRONG@ALSOWRONG",
+            "--broker",
+            "redis://localhost:6379/0",
+            "--ping-timeout",
+            "5",
+            "--skip-event-loop-liveness",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code == _WORKER_EXIT_CODE_PING_FAILURE
+
+
+def test_ping_fails_wrong_broker(start_worker_process: subprocess.Popen):
+    _wait_until(_ping_ready, timeout=10)
+
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--no-skip-ping",
+            "--worker-name",
+            "celery@test",
+            "--broker",
+            "redis://127.0.0.1:9999/0",
+            "--ping-timeout",
+            "5",
+            "--skip-event-loop-liveness",
+            "--skip-readiness",
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+#
+# READINESS
+#
+def test_readiness_is_not_a_file():
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--no-skip-readiness",
+            "--readiness-file",
+            "/",
+            "--skip-event-loop-liveness",
+            "--skip-ping",
+        ],
+    )
+
+    assert result.exit_code == _WORKER_EXIT_CODE_NOT_READY
+
+
+def test_readiness_exists(tmp_path: Path):
+    test_file = tmp_path / "test"
+    test_file.touch()
+
+    result = runner.invoke(
+        app,
+        [
+            "worker-health-check",
+            "--no-skip-readiness",
+            "--readiness-file",
+            str(test_file),
+            "--skip-event-loop-liveness",
+            "--skip-ping",
+        ],
+    )
+
+    assert result.exit_code == 0

--- a/tests/health_checks/test_celery_worker_health_checks.py
+++ b/tests/health_checks/test_celery_worker_health_checks.py
@@ -1,0 +1,199 @@
+# Celery is specified in the test dependencies already for the otel instrumentation, so
+# we can rely on it being available for health-check tests.
+
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from celery import Celery
+
+from maykin_common.health_checks.celery.probes import (
+    EventLoopProbe,
+    connect_worker_signals,
+)
+
+ROOT_DIR = Path(__file__).parent.parent.parent.resolve()
+
+app = Celery("maykin-common-tests", broker="redis://localhost:6379/0")
+# signals must be connected in the process that runs worker - this module is imported
+# again via the start_worker_process fixture which starts a subprocess
+connect_worker_signals()
+assert app.steps is not None
+app.steps["worker"].add(EventLoopProbe)
+
+
+@pytest.fixture(autouse=True)
+def install_celery_health_checks(settings):
+    settings.INSTALLED_APPS = [
+        *settings.INSTALLED_APPS,
+        "maykin_common.health_checks.celery",
+    ]
+
+
+@pytest.fixture
+def worker_event_loop_liveness_file(request, tmp_path: Path) -> Path:
+    marker = request.node.get_closest_marker("worker_event_loop_liveness_file")
+    subpath = marker.kwargs.get("subpath") if marker else ""
+    dir_path = tmp_path
+    if subpath:
+        dir_path /= subpath
+    return dir_path / "worker_live"
+
+
+@pytest.fixture
+def worker_readiness_file(request, tmp_path: Path) -> Path:
+    marker = request.node.get_closest_marker("worker_readiness_file")
+    subpath = marker.kwargs.get("subpath") if marker else ""
+    dir_path = tmp_path
+    if subpath:
+        dir_path /= subpath
+    return dir_path / "worker_ready"
+
+
+@pytest.fixture
+def start_worker_process(
+    worker_event_loop_liveness_file: Path, worker_readiness_file: Path
+):
+    """
+    Start a subprocess running worker and stop it when the test exits.
+    """
+    assert not worker_event_loop_liveness_file.exists(), (
+        "worker liveness file should not yet exist"
+    )
+    assert not worker_readiness_file.exists(), (
+        "worker readiness file should not yet exist"
+    )
+
+    cmd = [
+        "celery",
+        "--workdir",
+        str(ROOT_DIR),
+        "--app",
+        __name__,
+        "worker",
+        "--loglevel",
+        "CRITICAL",
+    ]
+    env = os.environ.copy()
+    env["MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_PROBE_FREQUENCY_SECONDS"] = "1"
+    env["MKN_HEALTH_CHECKS_WORKER_EVENT_LOOP_LIVENESS_FILE"] = str(
+        worker_event_loop_liveness_file
+    )
+    env["MKN_HEALTH_CHECKS_WORKER_READINESS_FILE"] = str(worker_readiness_file)
+
+    # start the process and let it run in the background - it should not exit by itself.
+    proc = subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+    try:
+        yield proc
+    finally:
+        is_running = proc.poll() is None
+        if not is_running:
+            return  # noqa: B012
+        proc.terminate()
+        # allow sufficient shutdown time, as workers have hot/cold shutdowns
+        proc.wait(timeout=10)
+
+
+def _wait_until(
+    predicate: Callable[[], bool], *, timeout: float, interval: float = 0.1
+):
+    """
+    Poll predicate() until it returns True or timeout expires.
+    Returns True if condition met, False if timed out.
+    """
+    deadline = time.monotonic() + timeout
+
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+
+    raise AssertionError("Predicate was never satisfied")
+
+
+def test_worker_hooks_create_probe_files(
+    start_worker_process: subprocess.Popen[bytes],
+    worker_event_loop_liveness_file: Path,
+    worker_readiness_file: Path,
+):
+    """
+    Check that when worker is running and scheduling tasks, it touches a heartheat file.
+    """
+    _wait_until(
+        lambda: worker_event_loop_liveness_file.exists()
+        and worker_readiness_file.exists(),
+        timeout=5,
+    )
+
+    assert worker_event_loop_liveness_file.is_file()
+    assert worker_readiness_file.is_file()
+
+
+def test_worker_updates_file_stat(
+    start_worker_process: subprocess.Popen[bytes],
+    worker_event_loop_liveness_file: Path,
+):
+    # start up worker and wait until the liveness file is initially created
+    _wait_until(worker_event_loop_liveness_file.exists, timeout=5)
+    initial_modified = worker_event_loop_liveness_file.stat().st_mtime
+
+    # check that the modified at timestamp is updated because of hour every-second
+    # timer frequency
+    _wait_until(
+        lambda: worker_event_loop_liveness_file.stat().st_mtime - initial_modified > 1,
+        timeout=3,
+    )
+
+
+def test_worker_removes_probe_files_on_exit(
+    start_worker_process: subprocess.Popen[bytes],
+    worker_event_loop_liveness_file: Path,
+    worker_readiness_file: Path,
+):
+    _wait_until(
+        lambda: worker_event_loop_liveness_file.exists()
+        and worker_readiness_file.exists(),
+        timeout=5,
+    )
+
+    start_worker_process.terminate()
+    # allow sufficient shutdown time, as workers have hot/cold shutdowns
+    start_worker_process.wait(timeout=10)
+    assert start_worker_process.poll() is not None  # check that it's exited
+
+    assert not worker_readiness_file.exists()
+    assert not worker_event_loop_liveness_file.exists()
+
+
+@pytest.mark.worker_event_loop_liveness_file(subpath="subpath-to-create")
+@pytest.mark.worker_readiness_file(subpath="other-subpath-to-create")
+def test_intermediate_directories_are_created(
+    start_worker_process: subprocess.Popen[bytes],
+    tmp_path: Path,
+    worker_event_loop_liveness_file: Path,
+    worker_readiness_file: Path,
+):
+    _wait_until(
+        lambda: worker_event_loop_liveness_file.exists()
+        and worker_readiness_file.exists(),
+        timeout=5,
+    )
+
+    assert worker_event_loop_liveness_file.relative_to(tmp_path) == Path(
+        "subpath-to-create/worker_live"
+    )
+    assert worker_event_loop_liveness_file.is_file()
+
+    assert worker_readiness_file.relative_to(tmp_path) == Path(
+        "other-subpath-to-create/worker_ready"
+    )
+    assert worker_readiness_file.is_file()


### PR DESCRIPTION
Closes #48

**Changes**

- [x] Add event loop liveness probe
- [x] Hook into worker start/stop signals for readiness file
- [x] Add CLI tooling to test the liveness file
- [x] Add CLI tooling to ping a worker (from itself)
- [x] Add CLI tooling to test the readiness file
- [x] Update documentation