### PR TITLE
:bug: Fix config(split=True)

### DIFF
--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -61,14 +61,14 @@ def config(option: str, *, default: None, cast: Callable) -> Never: ...
 
 @overload
 def config[T](
-    option: str, *, default: object = undefined, cast: Callable[[str], T]
+    option: str, *, default: str | Undefined = undefined, cast: Callable[[str], T]
 ) -> T: ...
 
 
 def config[T](
     option: str,
     *,
-    default: T | Sequence[T] | None | Undefined = undefined,
+    default: T | Sequence[T] | None | str | Undefined = undefined,
     split: bool = False,
     cast: Callable[[str], T] | Undefined = undefined,
 ) -> str | None | T | Sequence[T]:

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -152,4 +152,18 @@ def test_read_unset_setting_with_custom_cast_fallback_to_default():
 
 def test_raise_typeerror_when_non_string_default_is_specified_together_with_cast():
     with pytest.raises(TypeError):
-        config("SOME_OPTIONAL_SETTING", default=123, cast=lambda x: x)
+        config("SOME_OPTIONAL_SETTING", default=123, cast=lambda x: x)  # pyright: ignore  expecting TypeError :)
+
+
+def test_casting_to_union_type(monkeypatch: pytest.MonkeyPatch):
+    result = config("SOME_PORT_OR_SOCKET", default="5432", cast=lambda s: s and int(s))
+    assert_type(result, int | str)
+
+    assert result == 5432
+
+    monkeypatch.setenv("SOME_PORT_OR_SOCKET", "")
+
+    set_result = config(
+        "SOME_PORT_OR_SOCKET", default="5432", cast=lambda s: s and int(s)
+    )
+    assert set_result == ""

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -97,6 +97,41 @@ def test_read_provided_list_setting_without_default(monkeypatch: pytest.MonkeyPa
     assert result == ["first", "second"]
 
 
+def test_read_provided_list_casting_to_default(monkeypatch: pytest.MonkeyPatch):
+    result = config(
+        "SOME_REQUIRED_COMMA_SEPARATED_LIST", default=range(6, 8), split=True
+    )
+
+    assert_type(result, list[int])
+    assert result == [6, 7]
+
+    monkeypatch.setenv("SOME_REQUIRED_COMMA_SEPARATED_LIST", "1,2,3,4")
+    set_result = config("SOME_REQUIRED_COMMA_SEPARATED_LIST", default=[1], split=True)
+
+    assert set_result == [1, 2, 3, 4]
+
+
+def test_read_provided_list_casting(monkeypatch: pytest.MonkeyPatch):
+    result = config(
+        "SOME_REQUIRED_COMMA_SEPARATED_LIST", default=range(8, 8), split=True, cast=int
+    )
+
+    assert_type(result, list[int])
+    assert result == []
+
+    monkeypatch.setenv("SOME_REQUIRED_COMMA_SEPARATED_LIST", "1,2,3,4")
+    set_result = config(
+        "SOME_REQUIRED_COMMA_SEPARATED_LIST", default=range(8, 8), split=True, cast=int
+    )
+
+    assert set_result == [1, 2, 3, 4]
+
+    monkeypatch.setenv("SOME_REQUIRED_COMMA_SEPARATED_LIST", "1,2,3,4")
+    no_default = config("SOME_REQUIRED_COMMA_SEPARATED_LIST", split=True, cast=int)
+
+    assert no_default == [1, 2, 3, 4]
+
+
 def test_read_provided_setting_with_custom_cast(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("SOME_OPTIONAL_SETTING", "2025-12-25")
 


### PR DESCRIPTION
The annotations suggested `list[T]` could be returned, but it always returned `list[str]`.

This will still break if `type(T)(str(T))` is not identity, but it works for ints, and that's the use case I have in conf I'm porting.
