### PR TITLE
:lock: Harden the PDF rendering security

### DIFF
--- a/testapp/templates/testapp/pdf/blocked_file_url.html
+++ b/testapp/templates/testapp/pdf/blocked_file_url.html
@@ -1,0 +1,12 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Local URL</title>
+    </head>
+    <body>
+        <img src="file:///etc/passwd">
+    </body>
+</html>


### PR DESCRIPTION
Apply an explicit allow-list for allowed URL resource links, limiting it to http(s) and data URIs. Projects that need more protocols can provided the 'allowed_protocols' parameter.