### PR TITLE
VCR: strip out credentials headers by default

### DIFF
--- a/maykin_common/vcr.py
+++ b/maykin_common/vcr.py
@@ -20,10 +20,10 @@ libraries`_ than requests.
 
 import inspect
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, Protocol, override
+from typing import Any, ClassVar, Protocol, override
 
 from django.test import SimpleTestCase, TestCase, TransactionTestCase, tag
 
@@ -85,6 +85,15 @@ class VCRMixin(_VCRMixin):
     will be used.
     """
 
+    VCR_FILTER_HEADERS: ClassVar[Collection[str]] = frozenset(
+        ("Authorization", "x-api-key")
+    )
+    """
+    Default set of request headers to filter out.
+
+    Passed to the ``filter_headers`` kwarg of VCR by default.
+    """
+
     @override
     def _get_cassette_library_dir(self):
         test_files = (
@@ -109,6 +118,7 @@ class VCRMixin(_VCRMixin):
             "record_mode": self.VCR_RECORD_MODE,
             # Decompress for human readable cassette diffs when re-recoding
             "decode_compressed_response": True,
+            "filter_headers": self.VCR_FILTER_HEADERS,
         } | super()._get_vcr_kwargs(**kwargs)
 
     def vcr_raises(

--- a/tests/vcr/files/vcr_cassettes/CustomVCRHeaderFilteringTests/test_can_specify_which_headers_to_strip.yaml
+++ b/tests/vcr/files/vcr_cassettes/CustomVCRHeaderFilteringTests/test_can_specify_which_headers_to_strip.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Authorization:
+      - supersecret
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://example.com/
+  response:
+    body:
+      string: '<!doctype html><html lang="en"><head><title>Example Domain</title><meta
+        name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh
+        auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example
+        Domain</h1><p>This domain is for use in documentation examples without needing
+        permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn
+        more</a></div></body></html>
+
+        '
+    headers:
+      Age:
+      - '11787'
+      CF-RAY:
+      - 9c47c0da6db11c0c-AMS
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html
+      Date:
+      - Tue, 27 Jan 2026 11:01:39 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      allow:
+      - GET, HEAD
+      cf-cache-status:
+      - HIT
+      content-length:
+      - '513'
+      last-modified:
+      - Fri, 23 Jan 2026 20:54:05 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/vcr/files/vcr_cassettes/VCRHeaderFilteringTests/test_strips_out_authorization_header_by_default.yaml
+++ b/tests/vcr/files/vcr_cassettes/VCRHeaderFilteringTests/test_strips_out_authorization_header_by_default.yaml
@@ -1,0 +1,53 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.5
+    method: GET
+    uri: https://example.com/
+  response:
+    body:
+      string: '<!doctype html><html lang="en"><head><title>Example Domain</title><meta
+        name="viewport" content="width=device-width, initial-scale=1"><style>body{background:#eee;width:60vw;margin:15vh
+        auto;font-family:system-ui,sans-serif}h1{font-size:1.5em}div{opacity:0.8}a:link,a:visited{color:#348}</style><body><div><h1>Example
+        Domain</h1><p>This domain is for use in documentation examples without needing
+        permission. Avoid use in operations.<p><a href="https://iana.org/domains/example">Learn
+        more</a></div></body></html>
+
+        '
+    headers:
+      Age:
+      - '11518'
+      CF-RAY:
+      - 9c47ba495e991c83-AMS
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/html
+      Date:
+      - Tue, 27 Jan 2026 10:57:10 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      allow:
+      - GET, HEAD
+      cf-cache-status:
+      - HIT
+      content-length:
+      - '513'
+      last-modified:
+      - Fri, 23 Jan 2026 20:54:05 GMT
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
Closes #20

The VCR mixin now strips out headers known to contain credentials by default, reducing the risk of accidentally committing credentials or tokens.