### PR TITLE
:bug: Fix passing in config(..., default: str, split=True)

### DIFF
--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -20,6 +20,17 @@ __all__ = ["config"]
 def config(option: str) -> str: ...
 
 
+# discourage passing a str default with split=True
+@overload
+def config[T](
+    option: str,
+    *,
+    default: str,
+    split: Literal[True],
+    cast: Callable[[str], T] | Undefined = undefined,
+) -> Never: ...
+
+
 @overload
 def config[T](
     option: str,
@@ -119,12 +130,14 @@ def config[T](
                     cast=Csv(cast=cast if callable(cast) else type(t)),
                     default=_dumps(default),
                 )
-            case []:
+            case [] | "":
                 return _config(
                     option,
                     cast=Csv(cast=cast if callable(cast) else lambda x: x),
                     default="",
                 )
+            case str(default):
+                return _config(option, cast=Csv(), default=default)
             case _:
                 if callable(cast):
                     return _config(option, cast=Csv(cast=cast))

--- a/tests/base/test_config.py
+++ b/tests/base/test_config.py
@@ -7,7 +7,7 @@ set up as expected.
 """
 
 from datetime import date
-from typing import assert_never, assert_type
+from typing import Never, assert_never, assert_type
 
 import decouple
 import pytest
@@ -168,6 +168,22 @@ def test_casting_to_union_type(monkeypatch: pytest.MonkeyPatch):
         "SOME_PORT_OR_SOCKET", default="5432", cast=lambda s: s and int(s)
     )
     assert set_result == ""
+
+
+def test_split_string_default():
+    # Passing in string default returned list[str] in 0.14.0
+    # This tests that we retain the runtime behaviour while making it a
+    # type checker hint which was intened with the
+    # instance(default, Undefined | Sequence)
+    # str is a Sequence, so that TypeError isn't raised for default: str
+
+    result: Never = config("SOME_UNSET_ENVVAR", default="", split=True)
+
+    assert result == []  # this worked in 0.14.0
+
+    result: Never = config("SOME_UNSET_ENVVAR", default="1,2,3", split=True)
+
+    assert result == ["1", "2", "3"]  # 0.14.0 behaviour
 
 
 @given(


### PR DESCRIPTION
Restore the 0.14.0 behaviour (in order to not break runtime) But make the type Never, so the line will be greyed out.

0.14.0 types allowed it and returned `list[str]`
But this had no test cases because it was intended to fail with a TypeError.

0.15.0 raised `decouple.UndefinedValueError` which is confusing.