### PR TITLE
Fix optional dependency celery causing otel setup issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,12 +55,12 @@ tests = [
     "pyright",
     "django-stubs",
     "decouple-types",
-    "celery",
     "redis",
 ]
 docs = [
     "sphinx",
     "sphinx-rtd-theme",
+    "celery",
 ]
 release = [
     "bump-my-version",

--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ extras =
 deps =
   django42: Django~=4.2.0
   django52: Django~=5.2.0
+  health_checks: celery
+  cli: celery
 skipsdist = True
 commands_pre =
     django-admin compilemessages --verbosity 0

--- a/tox.ini
+++ b/tox.ini
@@ -96,8 +96,9 @@ extras =
     tests
     docs
     health-checks
-    celery
 allowlist_externals = make
+deps =
+    celery
 commands_pre =
 commands=
     make SPHINXOPTS="-W" html
@@ -114,7 +115,8 @@ extras =
     vcr
     otel
     health-checks
-    celery
     cli
+deps =
+    celery
 commands_pre =
 commands = pyright


### PR DESCRIPTION
Closes #65

* Updated test setup to not install celery by default
* Made instrumentors (more) lazy