### PR TITLE
Fix bug in Sphinx envvar doc generation

### DIFF
--- a/maykin_common/documentation/config_directives.py
+++ b/maykin_common/documentation/config_directives.py
@@ -64,9 +64,9 @@ def document_param(
     :arg default: an optional override for the default of the environment variable
     :returns: the node with a list item to document the environment variable
     """
-    para = nodes.inline()
+    para = nodes.paragraph()
 
-    result = f"* ``{var.name}``: "
+    result = f"``{var.name}``: "
 
     if var.help_text:
         result += var.help_text
@@ -78,9 +78,17 @@ def document_param(
     if var.auto_display_default:
         # Use explicitly provided default to override the default defined in code
         default_value = default if default is not undefined else var.default
-        if default_value is not undefined:
-            text = "(empty string)" if default_value == "" else str(default_value)
-            result += f" Defaults to: ``{text}``."
+        match default_value:
+            case Undefined():
+                pass
+            case "" | []:
+                result += " Defaults to: ``(empty string)``."
+            case str(text):
+                result += f" Defaults to: ``{text}``."
+            case [*values]:
+                result += f" Defaults to: ``{','.join(map(str, values))}``."
+            case other:
+                result += f" Defaults to: ``{other}``."
 
     # Make sure the line is rendered as rST
     vl = ViewList()
@@ -91,7 +99,9 @@ def document_param(
     # TODO cleaner way to do this?
     para += nodes.raw("", "<br>", format="html")
 
-    return para
+    item = nodes.list_item()
+    item += para
+    return item
 
 
 def document_group(
@@ -104,10 +114,10 @@ def document_group(
     :arg state: the reStructuredText state machine state
     :returns: the node with list items to document the environment variables
     """
-    para = nodes.paragraph()
+    bullet_list = nodes.bullet_list()
     for var in group:
-        para += document_param(var, state)
-    return para
+        bullet_list += document_param(var, state)
+    return bullet_list
 
 
 class ConfigParamDirective(Directive):

--- a/tests/base/test_config_directives.py
+++ b/tests/base/test_config_directives.py
@@ -50,7 +50,7 @@ def test_config_param():
 
     doc = parse_rst(rst)
 
-    expected = "* DISABLE_2FA: disable 2fa. Defaults to: False.<br>"
+    expected = "DISABLE_2FA: disable 2fa. Defaults to: False.<br>"
 
     assert expected == doc
 
@@ -69,7 +69,7 @@ def test_config_param_override_default():
 
     doc = parse_rst(rst)
 
-    expected = "* DISABLE_2FA: disable 2fa. Defaults to: True.<br>"
+    expected = "DISABLE_2FA: disable 2fa. Defaults to: True.<br>"
 
     assert expected == doc
 
@@ -90,7 +90,7 @@ def test_config_param_do_not_display_default():
 
     doc = parse_rst(rst)
 
-    expected = "* DISABLE_2FA: disable 2fa.<br>"
+    expected = "DISABLE_2FA: disable 2fa.<br>"
 
     assert expected == doc
 
@@ -106,7 +106,7 @@ def test_config_param_default_empty_string():
 
     doc = parse_rst(rst)
 
-    expected = "* SUBPATH: subpath. Defaults to: (empty string).<br>"
+    expected = "SUBPATH: subpath. Defaults to: (empty string).<br>"
 
     assert expected == doc
 
@@ -120,7 +120,7 @@ def test_config_param_missing_help_text():
 
     doc = parse_rst(rst)
 
-    expected = "* DISABLE_2FA:  Defaults to: False.<br>"
+    expected = "DISABLE_2FA:  Defaults to: False.<br>"
 
     assert expected == doc
 
@@ -136,12 +136,12 @@ def test_config_param_no_default(monkeypatch):
 
     doc = parse_rst(rst)
 
-    expected = "* SOME_VAR: some var.<br>"
+    expected = "SOME_VAR: some var.<br>"
 
     assert expected == doc
 
 
-def test_config_param_variable_does_not_exist(monkeypatch):
+def test_config_param_variable_does_not_exist():
     rst = textwrap.dedent("""
         .. config-param:: NON_EXISTENT_VAR
     """)
@@ -174,8 +174,9 @@ def test_config_group():
     doc = parse_rst(rst)
 
     expected = (
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+        "DB_USER: db username. Defaults to: foo.<br>"
+        "\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>"
     )
 
     assert expected == doc
@@ -229,8 +230,9 @@ def test_config_group_do_not_add_var_to_docs():
     doc = parse_rst(rst)
 
     expected = (
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+        "DB_USER: db username. Defaults to: foo.<br>"
+        "\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>"
     )
 
     assert expected == doc
@@ -266,8 +268,9 @@ def test_config_group_members():
     doc = parse_rst(rst)
 
     expected = (
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+        "DB_USER: db username. Defaults to: foo.<br>"
+        "\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>"
     )
 
     assert expected == doc
@@ -303,8 +306,9 @@ def test_config_group_exclude_params():
     doc = parse_rst(rst)
 
     expected = (
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+        "DB_USER: db username. Defaults to: foo.<br>"
+        "\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>"
     )
 
     assert expected == doc
@@ -329,7 +333,7 @@ def test_config_all_params():
     config(
         "ALLOWED_HOSTS",
         split=True,
-        default="",
+        default=[],
         documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
     config(
@@ -346,12 +350,12 @@ def test_config_all_params():
 
     expected = (
         "Required\n\n"
-        "* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
+        "ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
         "Database\n\n"
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>\n\n"
+        "DB_USER: db username. Defaults to: foo.<br>\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>\n\n"
         "Optional\n\n"
-        "* SESSION_COOKIE_AGE: session cookie age. Defaults to: 1234.<br>"
+        "SESSION_COOKIE_AGE: session cookie age. Defaults to: 1234.<br>"
     )
 
     assert expected == doc
@@ -371,7 +375,7 @@ def test_config_all_params_cannot_use_members_groups_and_exclude_groups_together
     config(
         "ALLOWED_HOSTS",
         split=True,
-        default="",
+        default=[],
         documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
     config(
@@ -404,7 +408,7 @@ def test_config_all_params_exclude_groups():
     config(
         "ALLOWED_HOSTS",
         split=True,
-        default="",
+        default=[],
         documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
     config(
@@ -436,7 +440,7 @@ def test_config_all_params_exclude_groups():
     doc = parse_rst(rst)
 
     expected = (
-        "Required\n\n* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>"
+        "Required\n\nALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>"
     )
 
     assert expected == doc
@@ -456,7 +460,7 @@ def test_config_all_params_members_groups():
     config(
         "ALLOWED_HOSTS",
         split=True,
-        default="",
+        default=[],
         documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
     config(
@@ -474,10 +478,10 @@ def test_config_all_params_members_groups():
 
     expected = (
         "Required\n\n"
-        "* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
+        "ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
         "Database\n\n"
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+        "DB_USER: db username. Defaults to: foo.<br>\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>"
     )
 
     assert expected == doc
@@ -524,10 +528,10 @@ def test_config_all_params_exclude_params():
 
     expected = (
         "Database\n\n"
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>\n\n"
+        "DB_USER: db username. Defaults to: foo.<br>\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>\n\n"
         "Optional\n\n"
-        "* SESSION_COOKIE_AGE: session cookie age. Defaults to: 1234.<br>"
+        "SESSION_COOKIE_AGE: session cookie age. Defaults to: 1234.<br>"
     )
 
     assert expected == doc
@@ -547,7 +551,7 @@ def test_config_all_params_do_not_add_param_to_docs():
     config(
         "ALLOWED_HOSTS",
         split=True,
-        default="",
+        default=[],
         documentation=DocumentationParams(help_text="allowed hosts", group="Required"),
     )
     config(
@@ -567,10 +571,10 @@ def test_config_all_params_do_not_add_param_to_docs():
 
     expected = (
         "Required\n\n"
-        "* ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
+        "ALLOWED_HOSTS: allowed hosts. Defaults to: (empty string).<br>\n\n"
         "Database\n\n"
-        "* DB_USER: db username. Defaults to: foo.<br>"
-        "* DB_PASSWORD: db password. Defaults to: bar.<br>"
+        "DB_USER: db username. Defaults to: foo.<br>\n\n"
+        "DB_PASSWORD: db password. Defaults to: bar.<br>"
     )
 
     assert expected == doc


### PR DESCRIPTION

Generate a bullet list for envvar docs, not paragraphs starting with `* `.

The original markup in open-api-framework was a list. And generating at least the same visual output makes diffing after an update less painful.
