### PR TITLE
:wrench: Add additional linter rules in Ruff config

### DIFF
--- a/maykin_common/config.py
+++ b/maykin_common/config.py
@@ -8,7 +8,7 @@ import csv
 import io
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, Literal, Never, assert_never, overload
+from typing import Literal, Never, assert_never, overload
 
 from decouple import Csv, Undefined, config as _config, undefined
 
@@ -266,7 +266,7 @@ ENVVAR_OPTIONAL_GROUP = "Optional"
 @dataclass(slots=True)
 class EnvironmentVariable:
     name: str
-    default: Any
+    default: object
     help_text: str
     group: str | None = None
     auto_display_default: bool = True

--- a/maykin_common/templatetags/maykin_common.py
+++ b/maykin_common/templatetags/maykin_common.py
@@ -1,6 +1,5 @@
-from typing import Any
-
 from django import template
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 
@@ -21,7 +20,7 @@ def show_version_info():
 
 
 @register.simple_tag(takes_context=True)
-def show_environment_info(context: dict[str, Any]) -> str:
+def show_environment_info(context: dict[str, object]) -> str:
     """
     Template that show the current ENVIRONMENT to an authenticated user.
 
@@ -29,7 +28,9 @@ def show_environment_info(context: dict[str, Any]) -> str:
     """
     if not get_setting("SHOW_ENVIRONMENT"):
         return ""
-    if (user := context.get("user")) is None or not user.is_authenticated:
+    user = context.get("user")
+    assert isinstance(user, None | AbstractBaseUser | AnonymousUser)
+    if user is None or not user.is_authenticated:
         return ""
 
     style_tokens = {

--- a/maykin_common/vcr.py
+++ b/maykin_common/vcr.py
@@ -23,7 +23,7 @@ import os
 from collections.abc import Callable, Collection
 from contextlib import AbstractContextManager
 from pathlib import Path
-from typing import Any, ClassVar, Protocol, override
+from typing import ClassVar, Protocol, override
 
 from django.test import SimpleTestCase, TestCase, TransactionTestCase, tag
 
@@ -52,7 +52,7 @@ class _VCRTestCase(Protocol):
     def _get_cassette_name(self) -> str: ...
     def _get_vcr(self, **kwargs) -> VCR: ...
     # TypedDict is almost as cursed as Protocol :(
-    def _get_vcr_kwargs(self, **kwargs) -> dict[str, Any]: ...
+    def _get_vcr_kwargs(self, **kwargs) -> dict[str, object]: ...
 
 
 class VCRMixin(_VCRMixin):
@@ -152,7 +152,7 @@ class VCRMixin(_VCRMixin):
         # change the tests (iff it doesn't do anything with the Error arguments).
 
         kwargs = self._get_vcr_kwargs()
-        hook: _VCRBRRHook = kwargs.get("before_record_request") or (lambda _: None)
+        hook: _VCRBRRHook = kwargs.get("before_record_request") or (lambda _: None)  # pyright: ignore[reportAssignmentType]
 
         def raise_exception(request):
             # perform configured hook first

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,10 @@ extend-select = [
     "F",   # pyflakes
     "PERF",# perflint
     "B",   # flake8-bugbear
+    "TID251",# tidy-imports
+    "TID253",
+    # RUFF specific rules
+    "RUF018", # assignment in assert
 ]
 
 [tool.ruff.lint.isort]
@@ -186,3 +190,7 @@ section-order = [
 
 [tool.ruff.lint.isort.sections]
 "django" = ["django"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.cast".msg = "Casting is an anti-pattern, use `assert isinstance(...)` instead, or suppress the error."
+"typing.Any".msg = "Any is an anti-pattern, use a real type instead, or if that's not possible, use 'object'."

--- a/tests/base/test_templatetags.py
+++ b/tests/base/test_templatetags.py
@@ -14,7 +14,7 @@ def _render_environment_info(context=None):
     return tpl.render(Context(context or {})).strip()
 
 
-def test_environment_disabled(settings):
+def test_environment_disabled(settings, admin_user: User):
     settings.SHOW_ENVIRONMENT = False
 
     # without user
@@ -22,11 +22,11 @@ def test_environment_disabled(settings):
     assert result == ""
 
     # with user
-    result = _render_environment_info({"user": User})
+    result = _render_environment_info({"user": admin_user})
     assert result == ""
 
 
-def test_environment_enabled(settings):
+def test_environment_enabled(settings, admin_user: User):
     settings.SHOW_ENVIRONMENT = True
     settings.ENVIRONMENT_BACKGROUND_COLOR = "orange"
     settings.ENVIRONMENT_FOREGROUND_COLOR = "black"
@@ -38,7 +38,7 @@ def test_environment_enabled(settings):
 
     # with user
 
-    result = _render_environment_info({"user": User})
+    result = _render_environment_info({"user": admin_user})
     assert result != ""
     assertInHTML("my super duper env", result)
 


### PR DESCRIPTION
* Block cast and Any imports/usage from the typing library
* Added import-assignment prevention, as that breaks code when PYTHONOPTIMIZE is used.

#79 reminded me this wasn't set up yet